### PR TITLE
Added comment before parameter assignment

### DIFF
--- a/demo/cross_validation.jl
+++ b/demo/cross_validation.jl
@@ -5,6 +5,8 @@ using XGBoost
 dtrain = DMatrix("../data/agaricus.txt.train")
 dtest = DMatrix("../data/agaricus.txt.test")
 
+#Defining parameters for xgboost
+
 param = ["max_depth"=>2, "eta"=>1, "silent"=>1, "objective"=>"binary:logistic"]
 num_round = 2
 nfold = 5


### PR DESCRIPTION
Trivial comment before parameter definition.

As this is a walk-through, would it be better to specify/explain the general, boost and task parameters separately with comments?