### PR TITLE
Now locked to xgboost version 0.47 to fix builds.

### DIFF
--- a/deps/build.jl
+++ b/deps/build.jl
@@ -7,13 +7,13 @@ prefix=joinpath(BinDeps.depsdir(libxgboostwrapper),"usr")
 provides(BuildProcess,
            (@build_steps begin
                `rm -rf xgboost`
-               `git clone https://github.com/tqchen/xgboost.git`
+               `git clone https://github.com/dmlc/xgboost.git --recursive`
                CreateDirectory(prefix)
                CreateDirectory(joinpath(prefix, "lib"))
                @build_steps begin
                    ChangeDirectory("xgboost")
                    FileRule(joinpath(prefix,"lib","libxgboostwrapper.so"), @build_steps begin
-                       `git checkout master` # v0.40
+                       `git checkout 0.47` # v0.40
                        `bash build.sh`
                        `cp wrapper/libxgboostwrapper.so $prefix/lib`
                    end)


### PR DESCRIPTION
The API for XGBoost master changed last week. So this locks new installs to the last v0.4 release and also ensures submodules are correctly checked out.