### PR TITLE
Fix missing to be NaN in line with latest Python bindings

### DIFF
--- a/src/xgboost_lib.jl
+++ b/src/xgboost_lib.jl
@@ -40,7 +40,7 @@ type DMatrix
         finalizer(sp, JLFree)
         sp
     end
-    function DMatrix{T<:Real}(data::Array{T, 2}, missing = 0;kwargs...)
+    function DMatrix{T<:Real}(data::Array{T, 2}, missing = NaN32; kwargs...)
         handle = XGDMatrixCreateFromMat(convert(Array{Float32, 2}, data),
                                         convert(Float32, missing))
         for itm in kwargs


### PR DESCRIPTION
Fix in line with Python wrapper. 
See https://github.com/dmlc/xgboost/blob/master/python-package/xgboost/sklearn.py#L87
and https://github.com/dmlc/xgboost/pull/788 for reference