### PR TITLE
Fix travis.yml

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,17 +1,6 @@
-language: cpp
-compiler:
-  - clang
+language: julia
+julia:
+  - 0.4
+  - nightly
 notifications:
-  email: false
-env:
-  matrix:
-    - JULIAVERSION="juliareleases"
-    - JULIAVERSION="julianightlies"
-before_install:
-  - sudo add-apt-repository ppa:staticfloat/julia-deps -y
-  - sudo add-apt-repository ppa:staticfloat/${JULIAVERSION} -y
-  - sudo apt-get update -qq -y
-  - sudo apt-get install libpcre3-dev julia -y
-  - if [[ -a .git/shallow ]]; then git fetch --unshallow; fi
-script:
-  - julia -e 'Pkg.init(); Pkg.clone(pwd());'
+    email: false


### PR DESCRIPTION
This way it will actually build XGBoost and run `Pkg.test`

As an example of the old behavior, see here build logs from previous version of travis.yml: https://travis-ci.org/maximsch2/XGBoost.jl/builds/106593798