### PR TITLE
Make sparse and dense constructors consistent

### DIFF
--- a/src/xgboost_lib.jl
+++ b/src/xgboost_lib.jl
@@ -41,7 +41,7 @@ type DMatrix
         sp
     end
 
-    function DMatrix{T<:Real}(data::Array{T, 2}, missing = NaN32, transposed::Bool=false; kwargs...)
+    function DMatrix{T<:Real}(data::Array{T, 2}, transposed::Bool=false, missing = NaN32; kwargs...)
         handle = nothing
         if !transposed
             handle = XGDMatrixCreateFromMat(convert(Array{Float32, 2}, data), convert(Float32, missing))


### PR DESCRIPTION
Since the `transposed` argument is shared between dense and sparse constructors but the `missing` argument is not, I moved `missing` to the end of the argument list to allow `DMatrix(data,
true)` (which treats the data as transposed) to dispatch correctly for both sparse and dense arguments.

This is a breaking change. But the `missing` argument seems little used, and type-checks will flag an issue for anyone dependent on that argument.