### PR TITLE
add osx support on travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,7 @@
 language: julia
+os:
+  - linux
+  - osx
 julia:
   - 0.4
   - nightly


### PR DESCRIPTION
This package currently support `osx` while it didn't open tests on `osx` in .travis.yml.
The result is shown at [my own travis-ci](https://travis-ci.org/zhmz90/XGBoost.jl).
