### PR TITLE
also test 0.3 on travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,7 @@ os:
   - linux
   - osx
 julia:
+  - 0.3
   - 0.4
   - nightly
 notifications:

--- a/REQUIRE
+++ b/REQUIRE
@@ -1,3 +1,3 @@
-julia 0.3-
+julia 0.3
 BinDeps 0.3.5-
 Compat

--- a/deps/build.jl
+++ b/deps/build.jl
@@ -1,4 +1,5 @@
 using BinDeps
+using Compat
 @BinDeps.setup
 
 deps = [ libxgboostwrapper = library_dependency("xgboostwrapper", aliases = ["libxgboostwrapper.so"]) ]
@@ -21,4 +22,4 @@ provides(BuildProcess,
             end),
          libxgboostwrapper)
 
-@BinDeps.install Dict(:xgboostwrapper => :_xgboost)
+@BinDeps.install @compat(Dict(:xgboostwrapper => :_xgboost))

--- a/src/xgboost_lib.jl
+++ b/src/xgboost_lib.jl
@@ -1,6 +1,6 @@
-include("xgboost_wrapper_h.jl")
-
 using Compat
+
+include("xgboost_wrapper_h.jl")
 
 # TODO: Use reference instead of array for length
 


### PR DESCRIPTION
~~still supported according to REQUIRE~~ package now uses `Ref` so is broken on 0.3 - need to change the lower bound in REQUIRE if 0.3 support is being dropped