### PR TITLE
Require Julia v0.4

### DIFF
--- a/REQUIRE
+++ b/REQUIRE
@@ -1,3 +1,3 @@
-julia 0.3-
+julia 0.4
 BinDeps 0.3.5-
 Compat


### PR DESCRIPTION
There were too many issues with adding v0.3 support, so I think it is best to just stick with v0.4 for Julia. Since the current tagged release does not compile for either v0.4 or v0.3, for now tagging a 0.4 only release will only improve things.