### PR TITLE
Support building latest stable and master XGBoost + Julia code update

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,7 @@ os:
   - linux
   - osx
 julia:
-  - 0.4
+  - 0.5
   - nightly
 notifications:
     email: false

--- a/README.md
+++ b/README.md
@@ -2,23 +2,24 @@ XGBoost.jl
 ==========
 
 [![Build Status](https://travis-ci.org/dmlc/XGBoost.jl.svg?branch=master)](https://travis-ci.org/dmlc/XGBoost.jl)
-[![XGBoost](http://pkg.julialang.org/badges/XGBoost_0.4.svg)](http://pkg.julialang.org/?pkg=XGBoost&ver=0.4)
 [![XGBoost](http://pkg.julialang.org/badges/XGBoost_0.5.svg)](http://pkg.julialang.org/?pkg=XGBoost&ver=0.5)
 
 eXtreme Gradient Boosting Package in Julia
 
 ## Abstract
-This package is a Julia interface of [XGBoost](https://github.com/tqchen/xgboost),
-which is short for eXtreme Gradient Boosting.  It is an efficient and scalable implementation of
-gradient boosting framework. The package includes efficient linear model
-solver and tree learning algorithms. The library is parallelized using OpenMP,
-and it can be more than 10 times faster than some existing gradient boosting packages.
-It supports various objective functions, including regression, classification and ranking.
-The package is also made to be extensible, so that users are also allowed to define their own objectives easily.
+This package is a Julia interface of [XGBoost](https://github.com/tqchen/xgboost), which is short
+for eXtreme Gradient Boosting. It is an efficient and scalable implementation of gradient boosting
+framework. The package includes efficient linear model solver and tree learning algorithms. The
+library is parallelized using OpenMP, and it can be more than 10 times faster than some existing
+gradient boosting packages. It supports various objective functions, including regression,
+classification and ranking. The package is also made to be extensible, so that users are also
+allowed to define their own objectives easily.
 
 ## Features
-* Sparse feature format, it allows easy handling of missing values, and improve computation efficiency.
-* Advanced features, such as customized loss function, cross validation, see [demo folder](demo) for walkthrough examples.
+* Sparse feature format, it allows easy handling of missing values, and improve computation
+    efficiency.
+* Advanced features, such as customized loss function, cross validation, see [demo folder](demo)
+    for walkthrough examples.
 
 ## Installation
 ```julia
@@ -40,7 +41,10 @@ To show how XGBoost works, here is an example of dataset Mushroom
 
 - Prepare Data
 
-XGBoost support Julia ```Array```, ```SparseMatrixCSC```, libSVM format text and XGBoost binary file as input. Here is an example of Mushroom classification. This example will use the function ```readlibsvm``` in [basic_walkthrough.jl](demo/basic_walkthrough.jl#L5). This function load libsvm format text into Julia dense matrix.
+XGBoost support Julia ```Array```, ```SparseMatrixCSC```, libSVM format text and XGBoost binary
+file as input. Here is an example of Mushroom classification. This example will use the function
+```readlibsvm``` in [basic_walkthrough.jl](demo/basic_walkthrough.jl#L5). This function load libsvm
+format text into Julia dense matrix.
 
 ```julia
 using XGBoost
@@ -53,7 +57,7 @@ test_X, test_Y = readlibsvm("data/agaricus.txt.test", (1611, 126))
 - Fit Model
 ```julia
 num_round = 2
-bst = xgboost(train_X, num_round, label=train_Y, eta=1, max_depth=2)
+bst = xgboost(train_X, num_round, label = train_Y, eta = 1, max_depth = 2)
 ```
 
 ## Predict
@@ -65,9 +69,11 @@ print("test-error=", sum((pred .> 0.5) .!= test_Y) / float(size(pred)[1]), "\n")
 ## Cross-Validation
 ```julia
 nfold=5
-param = ["max_depth"=>2, "eta"=>1, "objective"=>"binary:logistic"]
+param = ["max_depth" => 2,
+         "eta" => 1,
+         "objective" => "binary:logistic"]
 metrics = ["auc"]
-nfold_cv(train_X, num_round, nfold, label=train_Y, param=param, metrics=metrics)
+nfold_cv(train_X, num_round, nfold, label = train_Y, param = param, metrics = metrics)
 ```
 
 ## Feature Walkthrough

--- a/README.md
+++ b/README.md
@@ -8,7 +8,6 @@ XGBoost.jl
 eXtreme Gradient Boosting Package in Julia
 
 ## Abstract
-
 This package is a Julia interface of [XGBoost](https://github.com/tqchen/xgboost),
 which is short for eXtreme Gradient Boosting.  It is an efficient and scalable implementation of
 gradient boosting framework. The package includes efficient linear model

--- a/README.md
+++ b/README.md
@@ -31,8 +31,9 @@ Pkg.clone("https://github.com/antinucleon/XGBoost.jl.git")
 Pkg.build("XGBoost")
 ```
 
-
-The `XGBoost` package also depends on the `BinDeps`
+By default, the package builds the latest stable version of the XGBoost library. To build the
+latest master, set the environment variable XGBOOST_BUILD_VERSION to "master" prior to installing
+or building the package (e.g. `ENV["XGBOOST_BUILD_VERSION"] = "master"`).
 
 
 ## Minimal examples
@@ -68,7 +69,7 @@ print("test-error=", sum((pred .> 0.5) .!= test_Y) / float(size(pred)[1]), "\n")
 
 ## Cross-Validation
 ```julia
-nfold=5
+nfold = 5
 param = ["max_depth" => 2,
          "eta" => 1,
          "objective" => "binary:logistic"]
@@ -80,7 +81,7 @@ nfold_cv(train_X, num_round, nfold, label = train_Y, param = param, metrics = me
 Check [demo](https://github.com/antinucleon/XGBoost.jl/blob/master/demo/)
 
 - [Basic walkthrough of features](demo/basic_walkthrough.jl)
-- [Cutomize loss function, and evaluation metric](demo/custom_objective.jl)
+- [Customize loss function, and evaluation metric](demo/custom_objective.jl)
 - [Boosting from existing prediction](demo/boost_from_prediction.jl)
 - [Predicting using first n trees](demo/predict_first_ntree.jl)
 - [Generalized Linear Model](demo/generalized_linear_model.jl)

--- a/REQUIRE
+++ b/REQUIRE
@@ -1,3 +1,2 @@
-julia 0.4
+julia 0.5
 BinDeps 0.3.5-
-Compat

--- a/demo/README.md
+++ b/demo/README.md
@@ -1,7 +1,7 @@
 XGBoost.jl Feature Walkthrough
 ====
 * [Basic walkthrough of features](basic_walkthrough.jl)
-* [Cutomize loss function, and evaluation metric](custom_objective.jl)
+* [Customize loss function, and evaluation metric](custom_objective.jl)
 * [Boosting from existing prediction](boost_from_prediction.jl)
 * [Predicting using first n trees](predict_first_ntree.jl)
 * [Generalized Linear Model](generalized_linear_model.jl)
@@ -9,6 +9,6 @@ XGBoost.jl Feature Walkthrough
 
 Notes
 ====
-* Contribution of exampls, benchmarks is more than welcomed!
-* If you like to share how you use xgboost to solve your problem, send a pull request:)
+* Contributing examples or benchmarks is highly appreciated!
+* If you like to share how you use xgboost to solve your problem, send a pull request :)
 

--- a/demo/basic_walkthrough.jl
+++ b/demo/basic_walkthrough.jl
@@ -34,14 +34,17 @@ num_round = 2
 print("training xgboost with dense matrix\n")
 # you can directly pass Julia's matrix or sparse matrix as data,
 # by calling xgboost(data, num_round, label=label, training-parameters)
-bst = xgboost(train_X, num_round, label = train_Y, eta=1, max_depth=2, objective="binary:logistic")
+bst = xgboost(train_X, num_round, label = train_Y, eta = 1, max_depth = 2,
+              objective = "binary:logistic")
 
 
 print("training xgboost with sparse matrix\n")
 sptrain = sparse(train_X)
 # alternatively, you can pass parameters in as a map
-param = ["max_depth"=>2, "eta"=>1, "objective"=>"binary:logistic"]
-bst = xgboost(sptrain, num_round, label = train_Y, param=param)
+param = ["max_depth" => 2,
+         "eta" => 1,
+         "objective" => "binary:logistic"]
+bst = xgboost(sptrain, num_round, label = train_Y, param = param)
 
 # you can also put in xgboost's DMatrix object
 # DMatrix stores label, data and other meta datas needed for advanced features
@@ -50,7 +53,8 @@ dtrain = DMatrix(train_X, label = train_Y)
 bst = xgboost(dtrain, num_round, eta = 1, objective = "binary:logistic")
 
 # you can also specify data as file path to a LibSVM format input
-bst = xgboost("../data/agaricus.txt.train", num_round, max_depth = 2, eta = 1, objective = "binary:logistic")
+bst = xgboost("../data/agaricus.txt.train", num_round, max_depth = 2, eta = 1,
+              objective = "binary:logistic")
 
 #--------------------basic prediction using XGBoost--------------
 # you can do prediction using the following line
@@ -76,7 +80,8 @@ dtest = DMatrix(test_X, label = test_Y)
 # DMatrix in watchlist should have label (for evaluation)
 watchlist  = [(dtest,"eval"), (dtrain,"train")]
 # we can change evaluation metrics, or use multiple evaluation metrics
-bst = xgboost(dtrain, num_round, param=param, watchlist=watchlist, metrics=["logloss", "error"])
+bst = xgboost(dtrain, num_round, param = param, watchlist = watchlist,
+              metrics = ["logloss", "error"])
 
 # we can also save DMatrix into binary file, then we can load it faster next time
 save(dtest, "dtest.buffer")
@@ -95,4 +100,4 @@ print("test-error=", sum((pred .> 0.5) .!= label) / float(size(pred)[1]), "\n")
 # Finally, you can dump the tree you learned using dump_model into a text file
 dump_model(bst, "dump.raw.txt")
 # If you have feature map file, you can dump the model in a more readable way
-dump_model(bst, "dump.nice.txt", fmap="../data/featmap.txt")
+dump_model(bst, "dump.nice.txt", fmap = "../data/featmap.txt")

--- a/demo/basic_walkthrough.jl
+++ b/demo/basic_walkthrough.jl
@@ -32,8 +32,8 @@ test_X, test_Y = readlibsvm("../data/agaricus.txt.test", (1611, 126))
 num_round = 2
 
 print("training xgboost with dense matrix\n")
-# you can directly pass julia's matrix or sparse matrix as data,
-#   by calling xgboost(data, num_round, label=label, training-parameters)
+# you can directly pass Julia's matrix or sparse matrix as data,
+# by calling xgboost(data, num_round, label=label, training-parameters)
 bst = xgboost(train_X, num_round, label = train_Y, eta=1, max_depth=2, objective="binary:logistic")
 
 
@@ -82,7 +82,7 @@ bst = xgboost(dtrain, num_round, param=param, watchlist=watchlist, metrics=["log
 save(dtest, "dtest.buffer")
 save(dtrain, "dtrain.buffer")
 
-# load model and data in
+# load model and data
 dtrain = DMatrix("dtrain.buffer")
 dtest = DMatrix("dtest.buffer")
 bst = Booster(model_file = "xgb.model")

--- a/demo/basic_walkthrough.jl
+++ b/demo/basic_walkthrough.jl
@@ -28,7 +28,7 @@ test_X, test_Y = readlibsvm("../data/agaricus.txt.test", (1611, 126))
 #-------------Basic Training using XGBoost-----------------
 # note: xgboost naturally handles sparse input
 # use sparse matrix when your feature is sparse(e.g. when you using one-hot encoding vector)
-# model paramters can be set as paramter for ```xgboost``` function, or use an Array{(ASCIIString, Any), 1}/Dict()
+# model parameters can be set as parameters for ```xgboost``` function, or use a Vector{String} / Dict()
 num_round = 2
 
 print("training xgboost with dense matrix\n")

--- a/demo/cross_validation.jl
+++ b/demo/cross_validation.jl
@@ -41,13 +41,13 @@ end
 nfold_cv(dtrain, num_round, nfold, param=param, metrics=["auc"],
          seed = 0, show_stdv = false, fpreproc=fpreproc)
 
-print ("running cross validation, with cutomsized loss function\n")
+print("running cross validation, with customized loss function\n")
 ###
 # you can also do cross validation with cutomized loss function
 # See custom_objective.py
 ##
 
-function logregobj(preds::Array{Float32, 1}, dtrain::DMatrix)
+function logregobj(preds::Vector{Float32}, dtrain::DMatrix)
         labels = get_info(dtrain, "label")
         preds = 1.0 ./ (1.0 + exp(-preds))
         grad = preds - labels
@@ -55,7 +55,7 @@ function logregobj(preds::Array{Float32, 1}, dtrain::DMatrix)
         return (grad, hess)
 end
 
-function evalerror(preds::Array{Float32, 1}, dtrain::DMatrix)
+function evalerror(preds::Vector{Float32}, dtrain::DMatrix)
     labels = get_info(dtrain, "label")
     # return a pair metric_name, result
     # since preds are margin(before logistic transformation, cutoff at 0)

--- a/demo/cross_validation.jl
+++ b/demo/cross_validation.jl
@@ -7,7 +7,10 @@ dtest = DMatrix("../data/agaricus.txt.test")
 
 #Defining parameters for xgboost
 
-param = ["max_depth"=>2, "eta"=>1, "silent"=>1, "objective"=>"binary:logistic"]
+param = ["max_depth" => 2,
+         "eta" => 1,
+         "silent" => 1,
+         "objective" => "binary:logistic"]
 num_round = 2
 nfold = 5
 
@@ -15,13 +18,13 @@ print ("running cross validation\n")
 # do cross validation, this will print result out as
 # [iteration]  metric_name:mean_value+std_value
 # std_value is standard deviation of the metric
-nfold_cv(dtrain, num_round, nfold, param = param, metrics=["error"], seed = 0)
+nfold_cv(dtrain, num_round, nfold, param = param, metrics = ["error"], seed = 0)
 
 print ("running cross validation, disable standard deviation display\n")
 # do cross validation, this will print result out as
 # [iteration]  metric_name:mean_value+std_value
 # std_value is standard deviation of the metric
-nfold_cv(dtrain, num_round, nfold, param = param, metrics=["error"], seed = 0, show_stdv = false)
+nfold_cv(dtrain, num_round, nfold, param = param, metrics = ["error"], seed = 0, show_stdv = false)
 
 print ("running cross validation, with preprocessing function\n")
 # define the preprocessing function
@@ -32,14 +35,14 @@ function fpreproc(dtrain::DMatrix, dtest::DMatrix, param)
     label = get_info(dtrain, "label")
     ratio = sum(label == 0) / sum(label == 1)
     param["scale_pos_weight"] = ratio
-    return (dtrain, dtest, param)
+    return dtrain, dtest, param
 end
 # do cross validation, for each fold
 # the dtrain, dtest, param will be passed into fpreproc
 # then the return value of fpreproc will be used to generate
 # results of that fold
-nfold_cv(dtrain, num_round, nfold, param=param, metrics=["auc"],
-         seed = 0, show_stdv = false, fpreproc=fpreproc)
+nfold_cv(dtrain, num_round, nfold, param = param, metrics = ["auc"],
+         seed = 0, show_stdv = false, fpreproc = fpreproc)
 
 print("running cross validation, with customized loss function\n")
 ###
@@ -51,18 +54,17 @@ function logregobj(preds::Vector{Float32}, dtrain::DMatrix)
         labels = get_info(dtrain, "label")
         preds = 1.0 ./ (1.0 + exp(-preds))
         grad = preds - labels
-        hess = preds .* (1.0-preds)
-        return (grad, hess)
+        hess = preds .* (1. - preds)
+        return grad, hess
 end
 
 function evalerror(preds::Vector{Float32}, dtrain::DMatrix)
     labels = get_info(dtrain, "label")
     # return a pair metric_name, result
     # since preds are margin(before logistic transformation, cutoff at 0)
-    return ("self-error", sum((preds .> 0.0) .!= labels) / float(size(preds)[1]))
+    return "self-error", sum((preds .> 0.0) .!= labels) / float(size(preds)[1])
 end
 
 # train with customized objective
-nfold_cv(dtrain, num_round, nfold, metrics=[],
-         seed = 0, obj=logregobj, feval=evalerror,
-         max_depth=2, eta=1, silent=1)
+nfold_cv(dtrain, num_round, nfold, metrics = [], seed = 0, obj = logregobj, feval = evalerror,
+         max_depth = 2, eta = 1, silent = 1)

--- a/demo/custom_objective.jl
+++ b/demo/custom_objective.jl
@@ -16,7 +16,7 @@ param = ["max_depth"=>2, "eta"=>1, "silent"=>1]
 watchlist  = [(dtest,"eval"), (dtrain,"train")]
 num_round = 2
 
-function logregobj(preds::Array{Float32, 1}, dtrain::DMatrix)
+function logregobj(preds::Vector{Float32}, dtrain::DMatrix)
     labels = get_info(dtrain, "label")
     preds = 1.0 ./ (1.0 + exp(-preds))
     grad = preds - labels
@@ -30,7 +30,7 @@ end
 # for example, we are doing logistic loss, the prediction is score before logistic transformation
 # the buildin evaluation error assumes input is after logistic transformation
 # Take this in mind when you use the customization, and maybe you need write customized evaluation function
-function evalerror(preds::Array{Float32, 1}, dtrain::DMatrix)
+function evalerror(preds::Vector{Float32}, dtrain::DMatrix)
     labels = get_info(dtrain, "label")
     # return a pair metric_name, result
     # since preds are margin(before logistic transformation, cutoff at 0)

--- a/demo/predict_first_ntree.jl
+++ b/demo/predict_first_ntree.jl
@@ -3,18 +3,21 @@ using XGBoost
 dtrain = DMatrix("../data/agaricus.txt.train")
 dtest = DMatrix("../data/agaricus.txt.test")
 
-param = ["max_depth"=>2, "eta"=>1, "silent"=>0, "objective"=>"binary:logistic"]
+param = ["max_depth" => 2,
+         "eta" => 1,
+         "silent" => 0,
+         "objective" => "binary:logistic"]
 watchlist  = [(dtest,"eval"), (dtrain,"train")]
 num_round = 3
 
-bst = xgboost(dtrain, num_round, param=param, watchlist=watchlist)
+bst = xgboost(dtrain, num_round, param = param, watchlist = watchlist)
 
 
 print ("start testing prediction from first n trees\n")
 labels = get_info(dtest, "label")
 
 ### predict using first 1 tree
-pred1 = predict(bst, dtest, ntree_limit=1)
+pred1 = predict(bst, dtest, ntree_limit = 1)
 # by default, we predict using all the trees
 pred2 = predict(bst, dtest)
 

--- a/deps/build.jl
+++ b/deps/build.jl
@@ -1,24 +1,36 @@
 using BinDeps
+
 @BinDeps.setup
 
-deps = [ libxgboostwrapper = library_dependency("xgboostwrapper", aliases = ["libxgboost.so"]) ]
+xgboost = library_dependency("xgboost", aliases = ["libxgboost.so"])
 
-prefix = joinpath(BinDeps.depsdir(libxgboostwrapper),"usr")
+if haskey(ENV, "XGBOOST_BUILD_VERSION") && ENV["XGBOOST_BUILD_VERSION"] == "master"
+    libcheckout = `git checkout master`
+    onload = "global const build_version = \"master\""
+    info("Using the latest master version of the XGBoost library")
+else
+    libcheckout = `git checkout v0.60`
+    onload = "global const build_version = \"0.60\""
+    info("Using the latest stable version (0.60) of the XGBoost library")
+end
+
 provides(BuildProcess,
-         (@build_steps begin
-              `rm -rf xgboost`
-              `git clone https://github.com/dmlc/xgboost.git --recursive`
-              CreateDirectory(prefix)
-              CreateDirectory(joinpath(prefix, "lib"))
-              @build_steps begin
-                  ChangeDirectory("xgboost")
-                  FileRule(joinpath(prefix,"lib","libxgboost.so"),
-                           @build_steps begin
-                               `bash build.sh`
-                               `cp lib/libxgboost.so $prefix/lib`
-                           end)
-              end
-          end),
-         libxgboostwrapper)
+    FileRule(joinpath(BinDeps.libdir(xgboost), "libxgboost.so"),
+        @build_steps begin
+            CreateDirectory(BinDeps.srcdir(xgboost))
+            @build_steps begin
+                ChangeDirectory(BinDeps.srcdir(xgboost))
+                `rm -rf xgboost`
+                `git clone https://github.com/dmlc/xgboost.git --recursive`
+            end
 
-@BinDeps.install Dict(:xgboostwrapper => :_xgboost)
+            @build_steps begin
+                ChangeDirectory(joinpath(BinDeps.srcdir(xgboost), "xgboost"))
+                libcheckout
+                `bash build.sh`
+                CreateDirectory(BinDeps.libdir(xgboost))
+                `cp lib/libxgboost.so $(BinDeps.libdir(xgboost))`
+            end
+        end), xgboost, os = :Unix, onload = onload)
+
+@BinDeps.install Dict(:xgboost => :_jl_libxgboost)

--- a/deps/build.jl
+++ b/deps/build.jl
@@ -13,7 +13,6 @@ provides(BuildProcess,
                @build_steps begin
                    ChangeDirectory("xgboost")
                    FileRule(joinpath(prefix,"lib","libxgboostwrapper.so"), @build_steps begin
-                       `git checkout 0.47` # v0.40
                        `bash build.sh`
                        `cp wrapper/libxgboostwrapper.so $prefix/lib`
                    end)

--- a/deps/build.jl
+++ b/deps/build.jl
@@ -1,7 +1,7 @@
 using BinDeps
 @BinDeps.setup
 
-deps = [ libxgboostwrapper = library_dependency("xgboostwrapper", aliases = ["libxgboostwrapper.so"]) ]
+deps = [ libxgboostwrapper = library_dependency("xgboostwrapper", aliases = ["libxgboost.so"]) ]
 
 prefix=joinpath(BinDeps.depsdir(libxgboostwrapper),"usr")
 provides(BuildProcess,
@@ -12,9 +12,9 @@ provides(BuildProcess,
                CreateDirectory(joinpath(prefix, "lib"))
                @build_steps begin
                    ChangeDirectory("xgboost")
-                   FileRule(joinpath(prefix,"lib","libxgboostwrapper.so"), @build_steps begin
+                   FileRule(joinpath(prefix,"lib","libxgboost.so"), @build_steps begin
                        `bash build.sh`
-                       `cp wrapper/libxgboostwrapper.so $prefix/lib`
+                       `cp lib/libxgboost.so $prefix/lib`
                    end)
                end
             end),

--- a/deps/build.jl
+++ b/deps/build.jl
@@ -3,21 +3,22 @@ using BinDeps
 
 deps = [ libxgboostwrapper = library_dependency("xgboostwrapper", aliases = ["libxgboost.so"]) ]
 
-prefix=joinpath(BinDeps.depsdir(libxgboostwrapper),"usr")
+prefix = joinpath(BinDeps.depsdir(libxgboostwrapper),"usr")
 provides(BuildProcess,
-           (@build_steps begin
-               `rm -rf xgboost`
-               `git clone https://github.com/dmlc/xgboost.git --recursive`
-               CreateDirectory(prefix)
-               CreateDirectory(joinpath(prefix, "lib"))
-               @build_steps begin
-                   ChangeDirectory("xgboost")
-                   FileRule(joinpath(prefix,"lib","libxgboost.so"), @build_steps begin
-                       `bash build.sh`
-                       `cp lib/libxgboost.so $prefix/lib`
-                   end)
-               end
-            end),
+         (@build_steps begin
+              `rm -rf xgboost`
+              `git clone https://github.com/dmlc/xgboost.git --recursive`
+              CreateDirectory(prefix)
+              CreateDirectory(joinpath(prefix, "lib"))
+              @build_steps begin
+                  ChangeDirectory("xgboost")
+                  FileRule(joinpath(prefix,"lib","libxgboost.so"),
+                           @build_steps begin
+                               `bash build.sh`
+                               `cp lib/libxgboost.so $prefix/lib`
+                           end)
+              end
+          end),
          libxgboostwrapper)
 
 @BinDeps.install Dict(:xgboostwrapper => :_xgboost)

--- a/src/XGBoost.jl
+++ b/src/XGBoost.jl
@@ -1,7 +1,10 @@
+__precompile__()
+
 module XGBoost
 
 include("xgboost_lib.jl")
+
 export DMatrix, Booster
 export xgboost, predict, save, nfold_cv, slice, get_info, set_info, dump_model, importance
 
-end # module
+end # module XGBoost

--- a/src/XGBoost.jl
+++ b/src/XGBoost.jl
@@ -4,5 +4,4 @@ include("xgboost_lib.jl")
 export DMatrix, Booster
 export xgboost, predict, save, nfold_cv, slice, get_info, set_info, dump_model, importance
 
-
 end # module

--- a/src/xgboost_lib.jl
+++ b/src/xgboost_lib.jl
@@ -67,8 +67,8 @@ function set_info{T<:Real}(dmat::DMatrix, field::String, array::Vector{T})
     dmat._set_info(dmat.handle, field, array)
 end
 
-function save(dmat::DMatrix, fname::String; slient=true)
-    XGDMatrixSaveBinary(dmat.handle, fname, convert(Int32, slient))
+function save(dmat::DMatrix, fname::String; silent=true)
+    XGDMatrixSaveBinary(dmat.handle, fname, convert(Int32, silent))
 end
 
 ### slice ###

--- a/src/xgboost_lib.jl
+++ b/src/xgboost_lib.jl
@@ -82,7 +82,7 @@ end
 
 ### slice ###
 function slice{T<:Integer}(dmat::DMatrix, idxset::Vector{T})
-    handle = XGDMatrixSliceDMatrix(dmat.handle, convert(Vector{Int32}, idxset) - 1,
+    handle = XGDMatrixSliceDMatrix(dmat.handle, convert(Vector{Int32}, idxset - 1),
                                    convert(UInt64, size(idxset)[1]))
     return DMatrix(handle)
 end

--- a/src/xgboost_lib.jl
+++ b/src/xgboost_lib.jl
@@ -5,7 +5,7 @@ include("xgboost_wrapper_h.jl")
 type DMatrix
     handle::Ptr{Void}
     _set_info::Function
-    function _setinfo{T<:Number}(ptr::Ptr{Void}, name::String, array::Array{T, 1})
+    function _setinfo{T<:Number}(ptr::Ptr{Void}, name::String, array::Array{T,1})
         if name == "label" || name == "weight" || name == "base_margin"
             XGDMatrixSetFloatInfo(ptr, name,
                                   convert(Array{Float32, 1}, array),
@@ -29,7 +29,7 @@ type DMatrix
         finalizer(sp, JLFree)
         sp
     end
-    function DMatrix{K<:Real, V<:Integer}(data::SparseMatrixCSC{K, V}, transposed::Bool=false; kwargs...)
+    function DMatrix{K<:Real, V<:Integer}(data::SparseMatrixCSC{K,V}, transposed::Bool=false; kwargs...)
         handle = (transposed ? XGDMatrixCreateFromCSCT(data) : XGDMatrixCreateFromCSC(data))
         for itm in kwargs
             _setinfo(handle, string(itm[1]), itm[2])
@@ -39,7 +39,7 @@ type DMatrix
         sp
     end
 
-    function DMatrix{T<:Real}(data::Array{T, 2}, transposed::Bool=false, missing = NaN32; kwargs...)
+    function DMatrix{T<:Real}(data::Array{T,2}, transposed::Bool=false, missing = NaN32; kwargs...)
         handle = nothing
         if !transposed
             handle = XGDMatrixCreateFromMat(convert(Array{Float32, 2}, data), convert(Float32, missing))
@@ -63,7 +63,7 @@ function get_info(dmat::DMatrix, field::String)
     JLGetFloatInfo(dmat.handle, field)
 end
 
-function set_info{T<:Real}(dmat::DMatrix, field::String, array::Array{T, 1})
+function set_info{T<:Real}(dmat::DMatrix, field::String, array::Array{T,1})
     dmat._set_info(dmat.handle, field, array)
 end
 
@@ -72,15 +72,15 @@ function save(dmat::DMatrix, fname::String; slient=true)
 end
 
 ### slice ###
-function slice{T<:Integer}(dmat::DMatrix, idxset::Array{T, 1})
-    handle = XGDMatrixSliceDMatrix(dmat.handle, convert(Array{Int32, 1}, idxset) - 1,
+function slice{T<:Integer}(dmat::DMatrix, idxset::Array{T,1})
+    handle = XGDMatrixSliceDMatrix(dmat.handle, convert(Array{Int32,1}, idxset) - 1,
                                    convert(UInt64, size(idxset)[1]))
     return DMatrix(handle)
 end
 
 type Booster
     handle::Ptr{Void}
-    function Booster(;cachelist::Array{DMatrix, 1} = convert(Array{DMatrix,1}, []),
+    function Booster(;cachelist::Array{DMatrix,1} = convert(Array{DMatrix,1}, []),
                      model_file::String = "")
         handle = XGBoosterCreate([itm.handle for itm in cachelist], size(cachelist)[1])
         if model_file != ""
@@ -178,8 +178,8 @@ function update(bst::Booster, nrounds::Integer, dtrain::DMatrix; obj=Union{})
         grad, hess = obj(pred, dtrain)
         @assert size(grad) == size(hess)
         XGBoosterBoostOneIter(bst.handle, dtrain.handle,
-                              convert(Array{Float32, 1}, grad),
-                              convert(Array{Float32, 1}, hess),
+                              convert(Array{Float32,1}, grad),
+                              convert(Array{Float32,1}, hess),
                               convert(UInt64, size(hess)[1]))
     else
         XGBoosterUpdateOneIter(bst.handle, convert(Int32, nrounds), dtrain.handle)
@@ -188,7 +188,7 @@ end
 
 
 ### eval_set ###
-function eval_set(bst::Booster, watchlist::Array{Tuple{DMatrix, String},1},
+function eval_set(bst::Booster, watchlist::Array{Tuple{DMatrix,String},1},
                   iter::Integer; feval=Union{})
     dmats = DMatrix[]
     evnames = String[]

--- a/src/xgboost_wrapper_h.jl
+++ b/src/xgboost_wrapper_h.jl
@@ -8,14 +8,13 @@ end
 
 "Calls an xgboost API function and correctly reports errors."
 macro xgboost(f, params...)
-    args = [param.args[1] for param in params]
-    types = [param.args[2] for param in params]
-
     return quote
-        err = ccall(($f, _jl_libxgboost), Int64, ($(types...),), $(args...))
+        err = ccall(($f, _jl_libxgboost), Int64,
+                    ($((esc(i.args[2]) for i in params)...),),
+                    $((esc(i.args[1]) for i in params)...))
         if err != 0
             err_msg = unsafe_string(ccall((:XGBGetLastError, _jl_libxgboost), Cstring, ()))
-            error("Call to XGBoost C function ", string($f), " failed: ", err_msg)
+            error("Call to XGBoost C function ", string($(esc(f))), " failed: ", err_msg)
         end
     end
 end

--- a/src/xgboost_wrapper_h.jl
+++ b/src/xgboost_wrapper_h.jl
@@ -28,9 +28,9 @@ end
 function XGDMatrixCreateFromCSC(data::SparseMatrixCSC)
     handle = Ref{Ptr{Void}}()
     @xgboost(:XGDMatrixCreateFromCSC,
-             convert(Array{UInt64, 1}, data.colptr - 1) => Ptr{UInt64},
-             convert(Array{UInt32, 1}, data.rowval - 1) => Ptr{UInt32},
-             convert(Array{Float32, 1}, data.nzval) => Ptr{Float32},
+             convert(Vector{UInt64}, data.colptr - 1) => Ptr{UInt64},
+             convert(Vector{UInt32}, data.rowval - 1) => Ptr{UInt32},
+             convert(Vector{Float32}, data.nzval) => Ptr{Float32},
              convert(UInt64, size(data.colptr)[1]) => UInt64,
              convert(UInt64, nnz(data)) => UInt64,
              handle => Ref{Ptr{Void}})
@@ -40,20 +40,20 @@ end
 function XGDMatrixCreateFromCSCT(data::SparseMatrixCSC)
     handle = Ref{Ptr{Void}}()
     @xgboost(:XGDMatrixCreateFromCSR,
-             convert(Array{UInt64, 1}, data.colptr - 1) => Ptr{UInt64},
-             convert(Array{UInt32, 1}, data.rowval - 1) => Ptr{UInt32},
-             convert(Array{Float32, 1}, data.nzval) => Ptr{Float32},
+             convert(Vector{UInt64}, data.colptr - 1) => Ptr{UInt64},
+             convert(Vector{UInt32}, data.rowval - 1) => Ptr{UInt32},
+             convert(Vector{Float32}, data.nzval) => Ptr{Float32},
              convert(UInt64, size(data.colptr)[1]) => UInt64,
              convert(UInt64, nnz(data)) => UInt64,
              handle => Ref{Ptr{Void}})
     return handle[]
 end
 
-function XGDMatrixCreateFromMat(data::Array{Float32,2}, missing::Float32)
+function XGDMatrixCreateFromMat(data::Matrix{Float32}, missing::Float32)
     XGDMatrixCreateFromMatT(transpose(data), missing)
 end
 
-function XGDMatrixCreateFromMatT(data::Array{Float32,2}, missing::Float32)
+function XGDMatrixCreateFromMatT(data::Matrix{Float32}, missing::Float32)
     ncol, nrow = size(data)
     handle = Ref{Ptr{Void}}()
     @xgboost(:XGDMatrixCreateFromMat,
@@ -65,7 +65,7 @@ function XGDMatrixCreateFromMatT(data::Array{Float32,2}, missing::Float32)
     return handle[]
 end
 
-function XGDMatrixSliceDMatrix(handle::Ptr{Void}, idxset::Array{Int32,1}, len::UInt64)
+function XGDMatrixSliceDMatrix(handle::Ptr{Void}, idxset::Vector{Int32}, len::UInt64)
     ret = Ref{Ptr{Void}}()
     @xgboost(:XGDMatrixSliceDMatrix,
              handle => Ptr{Void},
@@ -87,7 +87,7 @@ function XGDMatrixSaveBinary(handle::Ptr{Void}, fname::String, silent::Int32)
              silent => Int32)
 end
 
-function XGDMatrixSetFloatInfo(handle::Ptr{Void}, field::String, array::Array{Float32,1},
+function XGDMatrixSetFloatInfo(handle::Ptr{Void}, field::String, array::Vector{Float32},
                                len::UInt64)
     @xgboost(:XGDMatrixSetFloatInfo,
              handle => Ptr{Void},
@@ -96,7 +96,7 @@ function XGDMatrixSetFloatInfo(handle::Ptr{Void}, field::String, array::Array{Fl
              len => UInt64)
 end
 
-function XGDMatrixSetUIntInfo(handle::Ptr{Void}, field::String, array::Array{UInt32,1},
+function XGDMatrixSetUIntInfo(handle::Ptr{Void}, field::String, array::Vector{UInt32},
                               len::UInt64)
     @xgboost(:XGDMatrixSetUIntInfo,
              handle => Ptr{Void},
@@ -105,14 +105,14 @@ function XGDMatrixSetUIntInfo(handle::Ptr{Void}, field::String, array::Array{UIn
              len => UInt64)
 end
 
-function XGDMatrixSetGroup(handle::Ptr{Void}, array::Array{UInt32,1}, len::UInt64)
+function XGDMatrixSetGroup(handle::Ptr{Void}, array::Vector{UInt32}, len::UInt64)
     @xgboost(:XGDMatrixSetGroup,
              handle => Ptr{Void},
              array => Ptr{UInt32},
              len => UInt64)
 end
 
-function XGDMatrixGetFloatInfo(handle::Ptr{Void}, field::String, outlen::Array{UInt64,1})
+function XGDMatrixGetFloatInfo(handle::Ptr{Void}, field::String, outlen::Vector{UInt64})
     ret = Ref{Ptr{Float32}}()
     @xgboost(:XGDMatrixGetFloatInfo,
              handle => Ptr{Void},
@@ -122,7 +122,7 @@ function XGDMatrixGetFloatInfo(handle::Ptr{Void}, field::String, outlen::Array{U
     return ret[]
 end
 
-function XGDMatrixGetUIntInfo(handle::Ptr{Void}, field::String, outlen::Array{UInt64,1})
+function XGDMatrixGetUIntInfo(handle::Ptr{Void}, field::String, outlen::Vector{UInt64})
     ret = Ref{Ptr{UInt32}}()
     @xgboost(:XGDMatrixGetUIntInfo,
              handle => Ptr{Void},
@@ -152,7 +152,7 @@ function JLGetUintInfo(handle::Ptr{Void}, field::String)
     return unsafe_wrap(Array, ptr, len[1])
 end
 
-function XGBoosterCreate(cachelist::Array{Ptr{Void},1}, len::Int64)
+function XGBoosterCreate(cachelist::Vector{Ptr{Void}}, len::Int64)
     handle = Ref{Ptr{Void}}()
     @xgboost(:XGBoosterCreate,
              cachelist => Ptr{Ptr{Void}},
@@ -180,8 +180,8 @@ function XGBoosterUpdateOneIter(handle::Ptr{Void}, iter::Int32, dtrain::Ptr{Void
              dtrain => Ptr{Void})
 end
 
-function XGBoosterBoostOneIter(handle::Ptr{Void}, dtrain::Ptr{Void}, grad::Array{Float32,1},
-                               hess::Array{Float32,1}, len::UInt64)
+function XGBoosterBoostOneIter(handle::Ptr{Void}, dtrain::Ptr{Void}, grad::Vector{Float32},
+                               hess::Vector{Float32}, len::UInt64)
     @xgboost(:XGBoosterBoostOneIter,
              handle => Ptr{Void},
              dtrain => Ptr{Void},
@@ -190,8 +190,8 @@ function XGBoosterBoostOneIter(handle::Ptr{Void}, dtrain::Ptr{Void}, grad::Array
              len => UInt64)
 end
 
-function XGBoosterEvalOneIter(handle::Ptr{Void}, iter::Int32, dmats::Array{Ptr{Void},1},
-                              evnames::Array{String,1}, len::UInt64)
+function XGBoosterEvalOneIter(handle::Ptr{Void}, iter::Int32, dmats::Vector{Ptr{Void}},
+                              evnames::Vector{String}, len::UInt64)
     msg = Ref{Ptr{UInt8}}()
     @xgboost(:XGBoosterEvalOneIter,
              handle => Ptr{Void},
@@ -204,7 +204,7 @@ function XGBoosterEvalOneIter(handle::Ptr{Void}, iter::Int32, dmats::Array{Ptr{V
 end
 
 function XGBoosterPredict(handle::Ptr{Void}, dmat::Ptr{Void}, output_margin::Int32,
-                          ntree_limit::UInt32, len::Array{UInt64,1})
+                          ntree_limit::UInt32, len::Vector{UInt64})
     ret = Ref{Ptr{Float32}}()
     @xgboost(:XGBoosterPredict,
              handle => Ptr{Void},

--- a/src/xgboost_wrapper_h.jl
+++ b/src/xgboost_wrapper_h.jl
@@ -17,34 +17,34 @@ macro xgboost(f, params...)
 end
 
 function XGDMatrixCreateFromFile(fname::String, silent::Int32)
-    handle = Ref{Ptr{Void}}()
+    out = Ref{Ptr{Void}}()
     @xgboost(:XGDMatrixCreateFromFile,
-             fname => Ptr{UInt8},
-             silent => Int32,
-             handle => Ref{Ptr{Void}})
-    return handle[]
+             fname => Cstring,
+             silent => Cint,
+             out => Ref{Ptr{Void}})
+    return out[]
 end
 
 function XGDMatrixCreateFromCSC(data::SparseMatrixCSC)
-    handle = Ref{Ptr{Void}}()
+    out = Ref{Ptr{Void}}()
     @xgboost(:XGDMatrixCreateFromCSC,
-             convert(Vector{UInt64}, data.colptr - 1) => Ptr{UInt64},
-             convert(Vector{UInt32}, data.rowval - 1) => Ptr{UInt32},
-             convert(Vector{Float32}, data.nzval) => Ptr{Float32},
-             convert(UInt64, size(data.colptr)[1]) => UInt64,
-             convert(UInt64, nnz(data)) => UInt64,
-             handle => Ref{Ptr{Void}})
-    return handle[]
+             convert(Vector{UInt64}, data.colptr - 1) => Ptr{Culonglong},
+             convert(Vector{UInt32}, data.rowval - 1) => Ptr{Cuint},
+             convert(Vector{Float32}, data.nzval) => Ptr{Cfloat},
+             convert(UInt64, size(data.colptr)[1]) => Culonglong,
+             convert(UInt64, nnz(data)) => Culonglong,
+             out => Ref{Ptr{Void}})
+    return out[]
 end
 
 function XGDMatrixCreateFromCSCT(data::SparseMatrixCSC)
     handle = Ref{Ptr{Void}}()
     @xgboost(:XGDMatrixCreateFromCSR,
-             convert(Vector{UInt64}, data.colptr - 1) => Ptr{UInt64},
-             convert(Vector{UInt32}, data.rowval - 1) => Ptr{UInt32},
-             convert(Vector{Float32}, data.nzval) => Ptr{Float32},
-             convert(UInt64, size(data.colptr)[1]) => UInt64,
-             convert(UInt64, nnz(data)) => UInt64,
+             convert(Vector{UInt64}, data.colptr - 1) => Ptr{Culonglong},
+             convert(Vector{UInt32}, data.rowval - 1) => Ptr{Cuint},
+             convert(Vector{Float32}, data.nzval) => Ptr{Cfloat},
+             convert(UInt64, size(data.colptr)[1]) => Culonglong,
+             convert(UInt64, nnz(data)) => Culonglong,
              handle => Ref{Ptr{Void}})
     return handle[]
 end
@@ -57,10 +57,10 @@ function XGDMatrixCreateFromMatT(data::Matrix{Float32}, missing::Float32)
     ncol, nrow = size(data)
     handle = Ref{Ptr{Void}}()
     @xgboost(:XGDMatrixCreateFromMat,
-             data => Ptr{Float32},
-             nrow => UInt64,
-             ncol => UInt64,
-             missing => Float32,
+             data => Ptr{Cfloat},
+             nrow => Culonglong,
+             ncol => Culonglong,
+             missing => Cfloat,
              handle => Ref{Ptr{Void}})
     return handle[]
 end
@@ -69,8 +69,8 @@ function XGDMatrixSliceDMatrix(handle::Ptr{Void}, idxset::Vector{Int32}, len::UI
     ret = Ref{Ptr{Void}}()
     @xgboost(:XGDMatrixSliceDMatrix,
              handle => Ptr{Void},
-             idxset => Ptr{Int32},
-             len => UInt64,
+             idxset => Ptr{Cint},
+             len => Culonglong,
              ret => Ref{Ptr{Void}})
     return ret[]
 end
@@ -83,82 +83,82 @@ end
 function XGDMatrixSaveBinary(handle::Ptr{Void}, fname::String, silent::Int32)
     @xgboost(:XGDMatrixSaveBinary,
              handle => Ptr{Void},
-             fname => Ptr{UInt8},
-             silent => Int32)
+             fname => Cstring,
+             silent => Cint)
 end
 
 function XGDMatrixSetFloatInfo(handle::Ptr{Void}, field::String, array::Vector{Float32},
                                len::UInt64)
     @xgboost(:XGDMatrixSetFloatInfo,
              handle => Ptr{Void},
-             field => Ptr{UInt8},
-             array => Ptr{Float32},
-             len => UInt64)
+             field => Cstring,
+             array => Ptr{Cfloat},
+             len => Culonglong)
 end
 
 function XGDMatrixSetUIntInfo(handle::Ptr{Void}, field::String, array::Vector{UInt32},
                               len::UInt64)
     @xgboost(:XGDMatrixSetUIntInfo,
              handle => Ptr{Void},
-             field => Ptr{UInt8},
-             array => Ptr{UInt32},
-             len => UInt64)
+             field => Cstring,
+             array => Ptr{Cuint},
+             len => Culonglong)
 end
 
 function XGDMatrixSetGroup(handle::Ptr{Void}, array::Vector{UInt32}, len::UInt64)
     @xgboost(:XGDMatrixSetGroup,
              handle => Ptr{Void},
-             array => Ptr{UInt32},
-             len => UInt64)
+             array => Ptr{Cuint},
+             len => Culonglong)
 end
 
-function XGDMatrixGetFloatInfo(handle::Ptr{Void}, field::String, outlen::Vector{UInt64})
-    ret = Ref{Ptr{Float32}}()
+function XGDMatrixGetFloatInfo(handle::Ptr{Void}, field::String, out_len::Vector{Culonglong})
+    out_dptr = Ref{Ptr{Cfloat}}()
     @xgboost(:XGDMatrixGetFloatInfo,
              handle => Ptr{Void},
-             field => Ptr{UInt8},
-             outlen => Ptr{UInt64},
-             ret =>  Ref{Ptr{Float32}})
-    return ret[]
-end
-
-function XGDMatrixGetUIntInfo(handle::Ptr{Void}, field::String, outlen::Vector{UInt64})
-    ret = Ref{Ptr{UInt32}}()
-    @xgboost(:XGDMatrixGetUIntInfo,
-             handle => Ptr{Void},
-             field => Ptr{UInt8},
-             outlen => Ptr{UInt64},
-             ret => Ref{Ptr{UInt32}})
-    return ret[]
-end
-
-function XGDMatrixNumRow(handle::Ptr{Void})
-    ret = Ref{UInt64}()
-    @xgboost(:XGDMatrixNumRow,
-             handle => Ptr{Void},
-             ret => Ref{UInt64})
-    return ret[]
+             field => Cstring,
+             out_len => Ptr{Culonglong},
+             out_dptr =>  Ref{Ptr{Cfloat}})
+    return out_dptr[]
 end
 
 function JLGetFloatInfo(handle::Ptr{Void}, field::String)
-    len = UInt64[1]
+    len = Culonglong[1]
     ptr = XGDMatrixGetFloatInfo(handle, field, len)
     return unsafe_wrap(Array, ptr, len[1])
 end
 
 function JLGetUintInfo(handle::Ptr{Void}, field::String)
-    len = UInt64[1]
+    len = Culonglong[1]
     ptr = XGDMatrixGetUIntInfo(handle, field, len)
     return unsafe_wrap(Array, ptr, len[1])
 end
 
+function XGDMatrixGetUIntInfo(handle::Ptr{Void}, field::String, out_len::Vector{Culonglong})
+    out_dptr = Ref{Ptr{Cuint}}()
+    @xgboost(:XGDMatrixGetUIntInfo,
+             handle => Ptr{Void},
+             field => Cstring,
+             out_len => Ptr{Culonglong},
+             out_dptr => Ref{Ptr{Cuint}})
+    return out_dptr[]
+end
+
+function XGDMatrixNumRow(handle::Ptr{Void})
+    out = Ref{Culonglong}()
+    @xgboost(:XGDMatrixNumRow,
+             handle => Ptr{Void},
+             out => Ref{Culonglong})
+    return out[]
+end
+
 function XGBoosterCreate(cachelist::Vector{Ptr{Void}}, len::Int64)
-    handle = Ref{Ptr{Void}}()
+    out = Ref{Ptr{Void}}()
     @xgboost(:XGBoosterCreate,
              cachelist => Ptr{Ptr{Void}},
-             len => UInt64,
-             handle => Ref{Ptr{Void}})
-    return handle[]
+             len => Culonglong,
+             out => Ref{Ptr{Void}})
+    return out[]
 end
 
 function XGBoosterFree(handle::Ptr{Void})
@@ -166,17 +166,17 @@ function XGBoosterFree(handle::Ptr{Void})
              handle => Ptr{Void})
 end
 
-function XGBoosterSetParam(handle::Ptr{Void}, key::String, value::String)
+function XGBoosterSetParam(handle::Ptr{Void}, name::String, value::String)
     @xgboost(:XGBoosterSetParam,
              handle => Ptr{Void},
-             key => Ptr{UInt8},
-             value => Ptr{UInt8})
+             name => Cstring,
+             value => Cstring)
 end
 
 function XGBoosterUpdateOneIter(handle::Ptr{Void}, iter::Int32, dtrain::Ptr{Void})
     @xgboost(:XGBoosterUpdateOneIter,
              handle => Ptr{Void},
-             iter => Int32,
+             iter => Cint,
              dtrain => Ptr{Void})
 end
 
@@ -185,57 +185,57 @@ function XGBoosterBoostOneIter(handle::Ptr{Void}, dtrain::Ptr{Void}, grad::Vecto
     @xgboost(:XGBoosterBoostOneIter,
              handle => Ptr{Void},
              dtrain => Ptr{Void},
-             grad => Ptr{Float32},
-             hess => Ptr{Float32},
-             len => UInt64)
+             grad => Ptr{Cfloat},
+             hess => Ptr{Cfloat},
+             len => Culonglong)
 end
 
 function XGBoosterEvalOneIter(handle::Ptr{Void}, iter::Int32, dmats::Vector{Ptr{Void}},
                               evnames::Vector{String}, len::UInt64)
-    msg = Ref{Ptr{UInt8}}()
+    out_result = Ref{Cstring}()
     @xgboost(:XGBoosterEvalOneIter,
              handle => Ptr{Void},
-             iter => Int32,
+             iter => Cint,
              dmats => Ptr{Ptr{Void}},
-             evnames => Ptr{Ptr{UInt8}},
-             len => UInt64,
-             msg => Ref{Ptr{UInt8}})
-    return unsafe_string(msg[])
+             evnames => Ptr{Cstring},
+             len => Culonglong,
+             out_result => Ref{Cstring})
+    return unsafe_string(out_result[])
 end
 
-function XGBoosterPredict(handle::Ptr{Void}, dmat::Ptr{Void}, output_margin::Int32,
-                          ntree_limit::UInt32, len::Vector{UInt64})
-    ret = Ref{Ptr{Float32}}()
+function XGBoosterPredict(handle::Ptr{Void}, dmat::Ptr{Void}, option_mask::Int32,
+                          ntree_limit::UInt32, out_len::Vector{UInt64})
+    out_result = Ref{Ptr{Float32}}()
     @xgboost(:XGBoosterPredict,
              handle => Ptr{Void},
              dmat => Ptr{Void},
-             output_margin => Int32,
-             ntree_limit => UInt32,
-             len => Ptr{UInt64},
-             ret => Ref{Ptr{Float32}})
-    return ret[]
+             option_mask => Cint,
+             ntree_limit => Cuint,
+             out_len => Ptr{Culonglong},
+             out_result => Ref{Ptr{Cfloat}})
+    return out_result[]
 end
 
 function XGBoosterLoadModel(handle::Ptr{Void}, fname::String)
     @xgboost(:XGBoosterLoadModel,
              handle => Ptr{Void},
-             fname => Ptr{UInt8})
+             fname => Cstring)
 end
 
 function XGBoosterSaveModel(handle::Ptr{Void}, fname::String)
     @xgboost(:XGBoosterSaveModel,
              handle => Ptr{Void},
-             fname => Ptr{UInt8})
+             fname => Cstring)
 end
 
 function XGBoosterDumpModel(handle::Ptr{Void}, fmap::String, with_stats::Int64)
-    data = Ref{Ptr{Ptr{UInt8}}}()
-    out_len = Ref{UInt64}(0)
+    out_dump_array = Ref{Ptr{Cstring}}()
+    out_len = Ref{Culonglong}(0)
     @xgboost(:XGBoosterDumpModel,
              handle => Ptr{Void},
-             fmap => Ptr{UInt8},
-             with_stats => Int64,
-             out_len => Ref{UInt64},
-             data => Ref{Ptr{Ptr{UInt8}}})
-    return unsafe_wrap(Array, data[], out_len[])
+             fmap => Cstring,
+             with_stats => Cint,
+             out_len => Ref{Culonglong},
+             out_dump_array => Ref{Ptr{Cstring}})
+    return unsafe_wrap(Array, out_dump_array[], out_len[])
 end

--- a/src/xgboost_wrapper_h.jl
+++ b/src/xgboost_wrapper_h.jl
@@ -14,7 +14,7 @@ macro xgboost_ccall(f, argTypes, args...)
     end
 end
 
-function XGDMatrixCreateFromFile(fname::Compat.ASCIIString, slient::Int32)
+function XGDMatrixCreateFromFile(fname::String, slient::Int32)
     handle = Ref{Ptr{Void}}()
     @xgboost_ccall(
         :XGDMatrixCreateFromFile,
@@ -86,7 +86,7 @@ function XGDMatrixFree(handle::Ptr{Void})
     )
 end
 
-function XGDMatrixSaveBinary(handle::Ptr{Void}, fname::Compat.ASCIIString, slient::Int32)
+function XGDMatrixSaveBinary(handle::Ptr{Void}, fname::String, slient::Int32)
     @xgboost_ccall(
         :XGDMatrixSaveBinary,
         (Ptr{Void}, Ptr{UInt8}, Int32),
@@ -94,7 +94,7 @@ function XGDMatrixSaveBinary(handle::Ptr{Void}, fname::Compat.ASCIIString, slien
     )
 end
 
-function XGDMatrixSetFloatInfo(handle::Ptr{Void}, field::Compat.ASCIIString,
+function XGDMatrixSetFloatInfo(handle::Ptr{Void}, field::String,
                                array::Array{Float32, 1}, len::UInt64)
     @xgboost_ccall(
         :XGDMatrixSetFloatInfo,
@@ -103,7 +103,7 @@ function XGDMatrixSetFloatInfo(handle::Ptr{Void}, field::Compat.ASCIIString,
     )
 end
 
-function XGDMatrixSetUIntInfo(handle::Ptr{Void}, field::Compat.ASCIIString,
+function XGDMatrixSetUIntInfo(handle::Ptr{Void}, field::String,
                               array::Array{UInt32, 1}, len::UInt64)
     @xgboost_ccall(
         :XGDMatrixSetUIntInfo,
@@ -120,7 +120,7 @@ function XGDMatrixSetGroup(handle::Ptr{Void}, array::Array{UInt32, 1}, len::UInt
     )
 end
 
-function XGDMatrixGetFloatInfo(handle::Ptr{Void}, field::Compat.ASCIIString, outlen::Array{UInt64, 1})
+function XGDMatrixGetFloatInfo(handle::Ptr{Void}, field::String, outlen::Array{UInt64, 1})
     ret = Ref{Ptr{Float32}}()
     @xgboost_ccall(
         :XGDMatrixGetFloatInfo,
@@ -130,7 +130,7 @@ function XGDMatrixGetFloatInfo(handle::Ptr{Void}, field::Compat.ASCIIString, out
     return ret[]
 end
 
-function XGDMatrixGetUIntInfo(handle::Ptr{Void}, field::Compat.ASCIIString, outlen::Array{UInt64, 1})
+function XGDMatrixGetUIntInfo(handle::Ptr{Void}, field::String, outlen::Array{UInt64, 1})
     ret = Ref{Ptr{UInt32}}()
     @xgboost_ccall(
         :XGDMatrixGetUIntInfo,
@@ -150,13 +150,13 @@ function XGDMatrixNumRow(handle::Ptr{Void})
     return ret[]
 end
 
-function JLGetFloatInfo(handle::Ptr{Void}, field::Compat.ASCIIString)
+function JLGetFloatInfo(handle::Ptr{Void}, field::String)
     len = UInt64[1]
     ptr = XGDMatrixGetFloatInfo(handle, field, len)
     return unsafe_wrap(Array, ptr, len[1])
 end
 
-function JLGetUintInfo(handle::Ptr{Void}, field::Compat.ASCIIString)
+function JLGetUintInfo(handle::Ptr{Void}, field::String)
     len = UInt64[1]
     ptr = XGDMatrixGetUIntInfo(handle, field, len)
     return unsafe_wrap(Array, ptr, len[1])
@@ -180,7 +180,7 @@ function XGBoosterFree(handle::Ptr{Void})
     )
 end
 
-function XGBoosterSetParam(handle::Ptr{Void}, key::Compat.ASCIIString, value::Compat.ASCIIString)
+function XGBoosterSetParam(handle::Ptr{Void}, key::String, value::String)
     @xgboost_ccall(
         :XGBoosterSetParam,
         (Ptr{Void}, Ptr{UInt8}, Ptr{UInt8}),
@@ -209,7 +209,7 @@ end
 
 function XGBoosterEvalOneIter(handle::Ptr{Void}, iter::Int32,
                               dmats::Array{Ptr{Void}, 1},
-                              evnames::Array{Compat.ASCIIString, 1}, len::UInt64)
+                              evnames::Array{String, 1}, len::UInt64)
     msg = Ref{Ptr{UInt8}}()
     @xgboost_ccall(
         :XGBoosterEvalOneIter,
@@ -232,7 +232,7 @@ function XGBoosterPredict(handle::Ptr{Void}, dmat::Ptr{Void}, output_margin::Int
 end
 
 
-function XGBoosterLoadModel(handle::Ptr{Void}, fname::Compat.ASCIIString)
+function XGBoosterLoadModel(handle::Ptr{Void}, fname::String)
     @xgboost_ccall(
         :XGBoosterLoadModel,
         (Ptr{Void}, Ptr{UInt8}),
@@ -240,7 +240,7 @@ function XGBoosterLoadModel(handle::Ptr{Void}, fname::Compat.ASCIIString)
     )
 end
 
-function XGBoosterSaveModel(handle::Ptr{Void}, fname::Compat.ASCIIString)
+function XGBoosterSaveModel(handle::Ptr{Void}, fname::String)
     @xgboost_ccall(
         :XGBoosterSaveModel,
         (Ptr{Void}, Ptr{UInt8}),
@@ -249,7 +249,7 @@ function XGBoosterSaveModel(handle::Ptr{Void}, fname::Compat.ASCIIString)
 end
 
 
-function XGBoosterDumpModel(handle::Ptr{Void}, fmap::Compat.ASCIIString, with_stats::Int64)
+function XGBoosterDumpModel(handle::Ptr{Void}, fmap::String, with_stats::Int64)
     data = Ref{Ptr{Ptr{UInt8}}}()
     out_len = Ref{UInt64}(0)
     @xgboost_ccall(

--- a/test/example.jl
+++ b/test/example.jl
@@ -12,20 +12,24 @@ test_X, test_Y = readlibsvm("../data/agaricus.txt.test", (1611, 126))
 #-------------Basic Training using XGBoost-----------------
 # note: xgboost naturally handles sparse input
 # use sparse matrix when your feature is sparse(e.g. when you using one-hot encoding vector)
-# model parameters can be set as parameters for ```xgboost``` function, or use a Vector{String} / Dict()
+# model parameters can be set as parameters for ```xgboost``` function, or use a Vector{String} or
+# Dict()
 num_round = 2
 
 print("training xgboost with dense matrix\n")
 # you can directly pass julia's matrix or sparse matrix as data,
 #   by calling xgboost(data, num_round, label=label, training-parameters)
-bst = xgboost(train_X, num_round, label = train_Y, eta=1, max_depth=2, objective="binary:logistic")
+bst = xgboost(train_X, num_round, label = train_Y, eta = 1, max_depth = 2,
+              objective = "binary:logistic")
 
 
 print("training xgboost with sparse matrix\n")
 sptrain = sparse(train_X)
 # alternatively, you can pass parameters in as a map
-param = Dict("max_depth"=>2, "eta"=>1, "objective"=>"binary:logistic")
-bst = xgboost(sptrain, num_round, label = train_Y, param=param)
+param = Dict("max_depth" => 2,
+             "eta" => 1,
+             "objective" => "binary:logistic")
+bst = xgboost(sptrain, num_round, label = train_Y, param = param)
 
 # you can also put in xgboost's DMatrix object
 # DMatrix stores label, data and other meta datas needed for advanced features
@@ -34,7 +38,8 @@ dtrain = DMatrix(train_X, label = train_Y)
 bst = xgboost(dtrain, num_round, eta = 1, objective = "binary:logistic")
 
 # you can also specify data as file path to a LibSVM format input
-bst = xgboost("../data/agaricus.txt.train", num_round, max_depth = 2, eta = 1, objective = "binary:logistic")
+bst = xgboost("../data/agaricus.txt.train", num_round, max_depth = 2, eta = 1,
+              objective = "binary:logistic")
 
 #--------------------basic prediction using XGBoost--------------
 # you can do prediction using the following line
@@ -60,7 +65,8 @@ dtest = DMatrix(test_X, label = test_Y)
 # DMatrix in watchlist should have label (for evaluation)
 watchlist  = [(dtest,"eval"), (dtrain,"train")]
 # we can change evaluation metrics, or use multiple evaluation metrics
-bst = xgboost(dtrain, num_round, param=param, watchlist=watchlist, metrics=["logloss", "error"])
+bst = xgboost(dtrain, num_round, param = param, watchlist = watchlist,
+              metrics = ["logloss", "error"])
 
 # we can also save DMatrix into binary file, then we can load it faster next time
 save(dtest, "dtest.buffer")
@@ -79,7 +85,7 @@ print("test-error=", sum((pred .> 0.5) .!= label) / float(size(pred)[1]), "\n")
 # You can dump the tree you learned using dump_model into a text file
 dump_model(bst, "dump.raw.txt")
 # If you have feature map file, you can dump the model in a more readable way
-dump_model(bst, "dump.nice.txt", fmap="../data/featmap.txt", with_stats=true)
+dump_model(bst, "dump.nice.txt", fmap = "../data/featmap.txt", with_stats = true)
 
 # You can also get information about feature importances in the model
-dump(importance(bst, fmap="../data/featmap.txt"))
+dump(importance(bst, fmap = "../data/featmap.txt"))

--- a/test/example.jl
+++ b/test/example.jl
@@ -12,7 +12,7 @@ test_X, test_Y = readlibsvm("../data/agaricus.txt.test", (1611, 126))
 #-------------Basic Training using XGBoost-----------------
 # note: xgboost naturally handles sparse input
 # use sparse matrix when your feature is sparse(e.g. when you using one-hot encoding vector)
-# model paramters can be set as paramter for ```xgboost``` function, or use an Array{(ASCIIString, Any), 1}/Dict()
+# model parameters can be set as parameters for ```xgboost``` function, or use a Vector{String} / Dict()
 num_round = 2
 
 print("training xgboost with dense matrix\n")

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -33,7 +33,8 @@ facts("Agaricus training") do
     dtest = DMatrix("../data/agaricus.txt.test")
     watchlist = [(dtest, "eval"), (dtrain, "train")]
 
-    bst = xgboost(dtrain, 2, watchlist=watchlist,  eta=1, max_depth=2, objective="binary:logistic", silent=1)
+    bst = xgboost(dtrain, 2, watchlist=watchlist, eta = 1, max_depth = 2,
+                  objective = "binary:logistic", silent = 1)
     @fact bst --> not(nothing)
 
     preds = XGBoost.predict(bst, dtest)
@@ -50,7 +51,8 @@ facts("Cross validation") do
     dtest = DMatrix("../data/agaricus.txt.test")
     watchlist = [(dtest, "eval"), (dtrain, "train")]
 
-    bst = nfold_cv(dtrain, 5, 3, eta=1, max_depth=2, objective="binary:logistic", silent=1, seed=12345)
+    bst = nfold_cv(dtrain, 5, 3, eta = 1, max_depth = 2, objective = "binary:logistic", silent = 1,
+                   seed = 12345)
     # important_features = importance(bst)
     #
     # @fact startswith(important_features[1].fname, "f28") --> true
@@ -62,7 +64,8 @@ facts("Feature importance") do
     dtest = DMatrix("../data/agaricus.txt.test")
     watchlist = [(dtest, "eval"), (dtrain, "train")]
 
-    bst = xgboost(dtrain, 5, watchlist=watchlist,  eta=1, max_depth=2, objective="binary:logistic", silent=1, seed=12345)
+    bst = xgboost(dtrain, 5, watchlist = watchlist, eta = 1, max_depth = 2,
+                  objective = "binary:logistic", silent = 1, seed = 12345)
     important_features = importance(bst)
 
     @fact startswith(important_features[1].fname, "f28") --> true

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -7,7 +7,7 @@ include("utils.jl")
 facts("Sparse matrices") do
     X = sparse(randn(100,10) .* bitrand(100,10))
     y = randn(100)
-    DMatrix(X, label=y)
+    DMatrix(X, label = y)
 
     X = sparse(convert(Matrix{Float32}, randn(10,100) .* bitrand(10,100)))
     y = randn(100)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -3,12 +3,13 @@ using FactCheck
 
 include("utils.jl")
 
+
 facts("Sparse matrices") do
     X = sparse(randn(100,10) .* bitrand(100,10))
     y = randn(100)
     DMatrix(X, label=y)
 
-    X = sparse(convert(Array{Float32,2}, randn(10,100) .* bitrand(10,100)))
+    X = sparse(convert(Matrix{Float32}, randn(10,100) .* bitrand(10,100)))
     y = randn(100)
     DMatrix(X, true)
 
@@ -27,7 +28,6 @@ facts("DMatrix loading") do
     @fact train_Y --> labels
 end
 
-
 facts("Agaricus training") do
     dtrain = DMatrix("../data/agaricus.txt.train")
     dtest = DMatrix("../data/agaricus.txt.test")
@@ -45,7 +45,6 @@ facts("Agaricus training") do
     @fact err --> less_than(0.1)
 end
 
-
 facts("Cross validation") do
     dtrain = DMatrix("../data/agaricus.txt.train")
     dtest = DMatrix("../data/agaricus.txt.test")
@@ -58,7 +57,6 @@ facts("Cross validation") do
     # @pending important_features[1].fname --> "f28"
 end
 
-
 facts("Feature importance") do
     dtrain = DMatrix("../data/agaricus.txt.train")
     dtest = DMatrix("../data/agaricus.txt.test")
@@ -70,7 +68,6 @@ facts("Feature importance") do
     @fact startswith(important_features[1].fname, "f28") --> true
     @pending important_features[1].fname --> "f28"
 end
-
 
 facts("Example is running") do
     include("example.jl")

--- a/test/utils.jl
+++ b/test/utils.jl
@@ -1,6 +1,4 @@
-import Compat: ASCIIString
-
-function readlibsvm(fname::ASCIIString, shape)
+function readlibsvm(fname::String, shape)
     dmx = zeros(Float32, shape)
     label = Float32[]
     fi = open(fname, "r")


### PR DESCRIPTION
This PR is a general update of the XGBoost.jl package, providing support for the latest stable and master versions of XGBoost and ensuring portability of the package code.

Most notably, the PR defaults to building the latest stable version (0.60) of the XGBoost library, but adds the option to build the latest master version. To support this, the Julia wrapper now uses Julia's system independent c types and automatically switches the appropriate type definitions based on the library version (stable or master). This also fixes https://github.com/dmlc/XGBoost.jl/issues/24.

In addition, the PR includes several minor improvements, namely:

- The package will now use precompilation.
- Fixed several spelling errors.
- No longer needs `eval()` in the wrapper macro.
- Improved formatting consistency.

Notable drawbacks of the PR are as follows:

- Breaks support with user's code where this relied on the misspelled `slient` keyword argument for various functions (e.g. `save()`).
- Break compatibility with Julia 0.4, but no longer requires the Compat package. With the Compat package, support for 0.4 could be added, but Julia 0.5 is now stable, and Julia 0.6 is just around the corner. I would therefore expect support for 0.4 to be dropped soon anyway.

After merging this PR, I intend to refactor some of the package's code to be more Julia and less Python, which should improve performance (e.g. by avoiding allocation and relying on multiple dispatch where possible).