### PR TITLE
Enable support for print_every_n and early_stopping_rounds

### DIFF
--- a/src/xgboost_lib.jl
+++ b/src/xgboost_lib.jl
@@ -307,12 +307,6 @@ function aggcv(rlist; show_stdv = true)
         k = item[1]
         v = item[2]
 
-        #if show_stdv == true
-        #    res = [res; [k; mean(v)]]
-        #else
-        #    res = [res; [k; mean(v); std(v)]]
-        #end
-
         if show_stdv == true
             res = [res k mean(v)]
         else

--- a/src/xgboost_wrapper_h.jl
+++ b/src/xgboost_wrapper_h.jl
@@ -10,8 +10,8 @@ end
 macro xgboost(f, params...)
     return quote
         err = ccall(($f, _jl_libxgboost), Int64,
-                    ($((esc(i.args[3]) for i in params)...),),
-                    $((esc(i.args[2]) for i in params)...))
+                    ($((esc(i.args[end]) for i in params)...),),
+                    $((esc(i.args[end - 1]) for i in params)...))
         if err != 0
             err_msg = unsafe_string(ccall((:XGBGetLastError, _jl_libxgboost), Cstring, ()))
             error("Call to XGBoost C function ", string($(esc(f))), " failed: ", err_msg)

--- a/src/xgboost_wrapper_h.jl
+++ b/src/xgboost_wrapper_h.jl
@@ -10,8 +10,8 @@ end
 macro xgboost(f, params...)
     return quote
         err = ccall(($f, _jl_libxgboost), Int64,
-                    ($((esc(i.args[2]) for i in params)...),),
-                    $((esc(i.args[1]) for i in params)...))
+                    ($((esc(i.args[3]) for i in params)...),),
+                    $((esc(i.args[2]) for i in params)...))
         if err != 0
             err_msg = unsafe_string(ccall((:XGBGetLastError, _jl_libxgboost), Cstring, ()))
             error("Call to XGBoost C function ", string($(esc(f))), " failed: ", err_msg)


### PR DESCRIPTION
Hello

I have recently been asking about adding additional parameters to nfold_cv (https://github.com/dmlc/XGBoost.jl/issues/40) and now I have done it myself.  
I have also addressed the issue described here: https://github.com/dmlc/XGBoost.jl/issues/42

I have added both print_every_n and early_stopping_rounds which are useful when running cross validation.

**print_every_n** - print each n-th iteration evaluation messages when silent = 0. Default is 1 which means all messages are printed. This parameter is passed to the nfold_cv or xgboost.

**early_stopping_rounds** - if not set, the early stopping function is not triggered. If set to an integer k > 0, training with a validation set will stop if the performance doesn't improve for k rounds. This parameter is passed to the nfold_cv or xgboost.

That's my first PR :)