### PR TITLE
bump xgboost version to 0.82

### DIFF
--- a/deps/build.jl
+++ b/deps/build.jl
@@ -10,9 +10,9 @@ if haskey(ENV, "XGBOOST_BUILD_VERSION") && ENV["XGBOOST_BUILD_VERSION"] == "mast
     onload = "global const build_version = \"master\""
     @info "Using the latest master version of the XGBoost library"
 else
-    libcheckout = `git checkout v0.80`
-    onload = "global const build_version = \"0.80\""
-    @info "Using the latest stable version (0.80) of the XGBoost library"
+    libcheckout = `git checkout v0.82`
+    onload = "global const build_version = \"0.82\""
+    @info "Using the latest stable version (0.82) of the XGBoost library"
 end
 
 provides(BuildProcess,


### PR DESCRIPTION
because 0.80 fails to compile, at least on Linux with the following error:

```
│ g++ -c -DDMLC_LOG_CUSTOMIZE=1 -std=c++11 -Wall -Wno-unknown-pragmas -Iinclude   -Idmlc-core/include -Irabit/include -I/include -O3 -funroll-loops -fPIC -DDISABLE_OPENMP src/data/data.cc -o build/data/data.o
│ In file included from src/data/data.cc:10:0:
│ src/data/./simple_dmatrix.h:19:7: error: looser throw specifier for 'virtual xgboost::data::SimpleDMatrix::~SimpleDMatrix() noexcept (false)'
│  class SimpleDMatrix : public DMatrix {
│        ^
│ In file included from src/data/data.cc:5:0:
│ include/xgboost/data.h:347:11: error:   overriding 'virtual xgboost::DMatrix::~DMatrix() noexcept'
│    virtual ~DMatrix() = default;
│            ^
│ Makefile:141: recipe for target 'build/data/data.o' failed
│ make: *** [build/data/data.o] Error 1
```