### PR TITLE
expose few Rabit APIs to help in parallelization

### DIFF
--- a/src/XGBoost.jl
+++ b/src/XGBoost.jl
@@ -7,7 +7,11 @@ using Statistics: mean, std
 
 export DMatrix, Booster
 export xgboost, predict, save, nfold_cv, slice, get_info, set_info, dump_model, importance
+export rabit_init, rabit_finalize, rabit_is_distributed, rabit_get_rank, rabit_get_world_size, rabit_get_version_number
 
+include("../deps/deps.jl")
+include("xgboost_wrapper_h.jl")
+include("rabit_wrapper.jl")
 include("xgboost_lib.jl")
 
 end # module XGBoost

--- a/src/rabit_wrapper.jl
+++ b/src/rabit_wrapper.jl
@@ -1,0 +1,16 @@
+rabit_finalize() = ccall((:RabitFinalize, _jl_libxgboost), Nothing, ())
+function rabit_init()
+    argv = Ref{Ptr{Nothing}}()
+    ccall((:RabitInit, _jl_libxgboost), Nothing, (Cint, Ref{Ptr{Nothing}}), 0, argv)
+end
+
+function rabit_is_distributed()
+    ret = ccall((:RabitIsDistributed, _jl_libxgboost), Cint, ())
+    return (ret != Cint(0))
+end
+
+rabit_get_rank() = ccall((:RabitGetRank, _jl_libxgboost), Cint, ())
+
+rabit_get_world_size() = ccall((:RabitGetWorldSize, _jl_libxgboost), Cint, ())
+
+rabit_get_version_number() = ccall((:RabitVersionNumber, _jl_libxgboost), Cint, ())

--- a/src/xgboost_lib.jl
+++ b/src/xgboost_lib.jl
@@ -1,5 +1,3 @@
-include("xgboost_wrapper_h.jl")
-
 # TODO: Use reference instead of array for length
 
 mutable struct DMatrix

--- a/src/xgboost_wrapper_h.jl
+++ b/src/xgboost_wrapper_h.jl
@@ -1,5 +1,3 @@
-include("../deps/deps.jl")
-
 const Bst_ulong = if build_version == "master"
     Culonglong
 else

--- a/test/rabit.jl
+++ b/test/rabit.jl
@@ -1,0 +1,10 @@
+function test_rabit()
+    rabit_init()
+    @test rabit_get_rank() == 0
+    @test rabit_get_world_size() == 1
+    @test !rabit_is_distributed()
+    @test rabit_get_version_number() == 0
+    rabit_finalize()
+end
+
+test_rabit()

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -79,4 +79,8 @@ end
     include("example.jl")
 end
 
+@testset "Rabit" begin
+    include("rabit.jl")
+end
+
 end


### PR DESCRIPTION
Expose the following Rabit APIs to help with multi-machine parallelization:
- `rabit_init`
- `rabit_finalize`
- `rabit_is_distributed`
- `rabit_get_rank`
- `rabit_get_world_size`
- `rabit_get_version_number`