### PR TITLE
Enabling CI for windows

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,6 +9,7 @@ julia:
   - 0.7
   - 1.0
   - 1.2
+  - 1.3
   - nightly
 
 matrix:

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,10 +3,12 @@ language: julia
 os:
   - linux
   - osx
-
+  - windows
+  
 julia:
   - 0.7
-  - 1.0.1
+  - 1.0
+  - 1.2
   - nightly
 
 matrix:


### PR DESCRIPTION
also makes sure CI runs on latest bug fix version of 1.0 and 1.2