### PR TITLE
add dump_model file format option

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -3,17 +3,17 @@ uuid = "009559a3-9522-5dbb-924b-0b6ed2b22bb9"
 version = "0.4.3"
 
 [deps]
-XGBoost_jll = "a5c6f535-4255-5ca2-a466-0e519f119c46"
 Libdl = "8f399da3-3557-5675-b5ff-fb832c97cbdb"
 Printf = "de0858da-6303-5e67-8744-51eddeeeb8d7"
 Random = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"
 SparseArrays = "2f01184e-e22b-5df5-ae63-d93ebab69eaf"
 Statistics = "10745b16-79ce-11e8-11f9-7d13ad32a3b2"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
+XGBoost_jll = "a5c6f535-4255-5ca2-a466-0e519f119c46"
 
 [compat]
-julia = "1.3"
 XGBoost_jll = "0.82"
+julia = "1.3"
 
 [extras]
 Random = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"

--- a/src/xgboost_lib.jl
+++ b/src/xgboost_lib.jl
@@ -110,15 +110,27 @@ function save(bst::Booster, fname::String)
 end
 
 ### dump model ###
-function dump_model(bst::Booster, fname::String; fmap::String="", with_stats::Bool = false)
-    data = XGBoosterDumpModel(bst.handle, fmap, convert(Int64, with_stats))
+function dump_model(bst::Booster, fname::String; fmap::String="", with_stats::Bool = false, dump_format::String="text")
+    data = XGBoosterDumpModel(bst.handle, fmap, convert(Int64, with_stats), dump_format)
     fo = open(fname, "w")
-    for i in 1:length(data)
-        @printf(fo, "booster[%d]:\n", i)
-        @printf(fo, "%s", unsafe_string(data[i]))
+    if dump_format == "json"
+        @printf(fo,"[\n");
+        for i in 1:length(data)
+            @printf(fo, "%s", unsafe_string(data[i]))
+            if i < length(data)
+                @printf(fo,",\n");
+            end
+        end
+        @printf(fo,"\n]");  
+    else
+        for i in 1:length(data)
+            @printf(fo, "booster[%d]:\n", i)
+            @printf(fo, "%s", unsafe_string(data[i]))
+        end
     end
     close(fo)
 end
+
 
 function makeDMatrix(data, label)
     # running converts

--- a/src/xgboost_wrapper_h.jl
+++ b/src/xgboost_wrapper_h.jl
@@ -229,13 +229,15 @@ function XGBoosterSaveModel(handle::Ptr{Nothing}, fname::String)
              fname => Cstring)
 end
 
-function XGBoosterDumpModel(handle::Ptr{Nothing}, fmap::String, with_stats::Int64)
+
+function XGBoosterDumpModel(handle::Ptr{Nothing}, fmap::String, with_stats::Int64, dump_format::String="text")
     out_dump_array = Ref{Ptr{Cstring}}()
     out_len = Ref{Bst_ulong}(0)
-    @xgboost(:XGBoosterDumpModel,
+    @xgboost(:XGBoosterDumpModelEx,
              handle => Ptr{Nothing},
              fmap => Cstring,
              with_stats => Cint,
+             dump_format => Cstring,
              out_len => Ref{Bst_ulong},
              out_dump_array => Ref{Ptr{Cstring}})
     return unsafe_wrap(Array, out_dump_array[], out_len[])

--- a/test/dump.nice.json
+++ b/test/dump.nice.json
@@ -1,0 +1,19 @@
+[
+  { "nodeid": 0, "depth": 0, "split": "odor=none", "yes": 2, "no": 1, "gain": 4000.53101, "cover": 1628.25, "children": [
+    { "nodeid": 1, "depth": 1, "split": "stalk-root=club", "yes": 4, "no": 3, "gain": 1158.21204, "cover": 924.5, "children": [
+      { "nodeid": 3, "leaf": 1.71217716, "cover": 812 },
+      { "nodeid": 4, "leaf": -1.70044053, "cover": 112.5 }
+    ]},
+    { "nodeid": 2, "depth": 1, "split": "spore-print-color=green", "yes": 6, "no": 5, "gain": 198.173828, "cover": 703.75, "children": [
+      { "nodeid": 5, "leaf": -1.94070864, "cover": 690.5 },
+      { "nodeid": 6, "leaf": 1.85964918, "cover": 13.25 }
+    ]}
+  ]},
+  { "nodeid": 0, "depth": 0, "split": "stalk-root=rooted", "yes": 2, "no": 1, "gain": 832.545044, "cover": 788.852051, "children": [
+    { "nodeid": 1, "depth": 1, "split": "odor=none", "yes": 4, "no": 3, "gain": 569.725098, "cover": 768.389709, "children": [
+      { "nodeid": 3, "leaf": 0.78471756, "cover": 458.936859 },
+      { "nodeid": 4, "leaf": -0.968530357, "cover": 309.45282 }
+    ]},
+    { "nodeid": 2, "leaf": -6.23624468, "cover": 20.462389 }
+  ]}
+]

--- a/test/dump.raw.json
+++ b/test/dump.raw.json
@@ -1,0 +1,19 @@
+[
+  { "nodeid": 0, "depth": 0, "split": 28, "split_condition": -9.53674316e-07, "yes": 1, "no": 2, "missing": 1, "children": [
+    { "nodeid": 1, "depth": 1, "split": 55, "split_condition": -9.53674316e-07, "yes": 3, "no": 4, "missing": 3, "children": [
+      { "nodeid": 3, "leaf": 1.71217716 },
+      { "nodeid": 4, "leaf": -1.70044053 }
+    ]},
+    { "nodeid": 2, "depth": 1, "split": 108, "split_condition": -9.53674316e-07, "yes": 5, "no": 6, "missing": 5, "children": [
+      { "nodeid": 5, "leaf": -1.94070864 },
+      { "nodeid": 6, "leaf": 1.85964918 }
+    ]}
+  ]},
+  { "nodeid": 0, "depth": 0, "split": 59, "split_condition": -9.53674316e-07, "yes": 1, "no": 2, "missing": 1, "children": [
+    { "nodeid": 1, "depth": 1, "split": 28, "split_condition": -9.53674316e-07, "yes": 3, "no": 4, "missing": 3, "children": [
+      { "nodeid": 3, "leaf": 0.78471756 },
+      { "nodeid": 4, "leaf": -0.968530357 }
+    ]},
+    { "nodeid": 2, "leaf": -6.23624468 }
+  ]}
+]

--- a/test/example.jl
+++ b/test/example.jl
@@ -84,8 +84,13 @@ print("test-error=", sum((pred .> 0.5) .!= label) / float(size(pred)[1]), "\n")
 
 # You can dump the tree you learned using dump_model into a text file
 dump_model(bst, "dump.raw.txt")
+# You can also dump the trees in JSON format
+dump_model(bst, "dump.raw.json", dump_format="json")
+
 # If you have feature map file, you can dump the model in a more readable way
 dump_model(bst, "dump.nice.txt", fmap = "../data/featmap.txt", with_stats = true)
+# You can also dump the trees in JSON format
+dump_model(bst, "dump.nice.json", fmap = "../data/featmap.txt", with_stats = true, dump_format="json")
 
 # You can also get information about feature importances in the model
 dump(importance(bst, fmap = "../data/featmap.txt"))


### PR DESCRIPTION
Provide the option of dump_model in JSON format. JSON format provides easier access to the tree structure (does not require parsing the dump file).

XGBoost allows providing file format options for the model_dump such as JSON format (see [here](https://github.com/dmlc/xgboost/pull/1726)). This pull request adds the capability to the Julia Wrapper.