### PR TITLE
Generate random indics using local seed rather global seed in cv

### DIFF
--- a/src/XGBoost.jl
+++ b/src/XGBoost.jl
@@ -3,7 +3,7 @@ module XGBoost
 using XGBoost_jll
 
 using Printf
-using Random: randperm, seed!
+using Random: randperm, MersenneTwister
 using SparseArrays: SparseMatrixCSC, nnz
 using Statistics: mean, std
 

--- a/src/xgboost_lib.jl
+++ b/src/xgboost_lib.jl
@@ -262,8 +262,8 @@ end
 
 function mknfold(dall::DMatrix, nfold::Integer, param, seed::Integer, evals=[]; fpreproc = Union{},
                  kwargs = [])
-    seed!(seed)
-    randidx = randperm(XGDMatrixNumRow(dall.handle))
+    randomseed = MersenneTwister(seed)
+    randidx = randperm(randomseed, XGDMatrixNumRow(dall.handle))
     kstep = size(randidx)[1] / nfold
     idset = [randidx[round(Int64, (i-1) * kstep) + 1 : min(size(randidx)[1],round(Int64, i * kstep))] for i in 1:nfold]
     ret = CVPack[]

--- a/src/xgboost_lib.jl
+++ b/src/xgboost_lib.jl
@@ -262,8 +262,8 @@ end
 
 function mknfold(dall::DMatrix, nfold::Integer, param, seed::Integer, evals=[]; fpreproc = Union{},
                  kwargs = [])
-    randomseed = MersenneTwister(seed)
-    randidx = randperm(randomseed, XGDMatrixNumRow(dall.handle))
+    rng = MersenneTwister(seed)
+    randidx = randperm(rng, XGDMatrixNumRow(dall.handle))
     kstep = size(randidx)[1] / nfold
     idset = [randidx[round(Int64, (i-1) * kstep) + 1 : min(size(randidx)[1],round(Int64, i * kstep))] for i in 1:nfold]
     ret = CVPack[]


### PR DESCRIPTION
Hello

Recantly I get puzzled on getting same random numbers when I was using `nfold_cv` to testify parameters. After reading the source code of that function, I don't think it's proper to change the global random seed.

So I have done some changes on the source code to fix that problem.

1. remove the importing of `Random:seed!`
2. import `Random:MersenneTwister` as seed generator
3. generate `randidx` using local seed without changing global seed