### PR TITLE
Run CI on `master` too

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,7 +2,7 @@ name: CI
 on:
   pull_request:
   push:
-    branches: [main]
+    branches: [master, main]
     tags: ['*']
 jobs:
   test:


### PR DESCRIPTION
My bad. I missed this when reviewing https://github.com/dmlc/XGBoost.jl/pull/111.