### PR TITLE
Add tests for saving/loading/serializing boosters

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,5 @@ deps
 test/*.buffer
 Manifest.toml
 docs/build
+
+test/*.xgb

--- a/.gitignore
+++ b/.gitignore
@@ -4,5 +4,3 @@ deps
 test/*.buffer
 Manifest.toml
 docs/build
-
-test/*.xgb

--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "XGBoost"
 uuid = "009559a3-9522-5dbb-924b-0b6ed2b22bb9"
-version = "2.0.0"
+version = "2.0.1"
 
 [deps]
 AbstractTrees = "1520ce14-60c1-5f80-bbc7-55ef81b5835c"

--- a/src/booster.jl
+++ b/src/booster.jl
@@ -149,7 +149,7 @@ Load a saved [`Booster`](@ref) model object from a file or buffer.
 This should load models stored via [`save`](@ref) (*not* `serialize` which may give
 incompatible buffers).
 """
-load(::Type{Booster}, fname::AbstractString) = Booster(DMatrix[], model_file=fanme)
+load(::Type{Booster}, fname::AbstractString) = Booster(DMatrix[], model_file=fname)
 load(::Type{Booster}, io) = Booster(DMatrix[], model_buffer=io)
 
 """
@@ -168,9 +168,9 @@ end
 function save(b::Booster, ::Type{Vector{UInt8}}; format::AbstractString="json")
     cfg = JSON3.write(Dict("format"=>format))
     olen = Ref{Lib.bst_ulong}()
-    o = Ref{Ptr{UInt8}}()
-    xgbcall(XGBoosterSaveModelToBuffer, cfg, olen, o)
-    unsafe_wrap(Array, o[], olen[])
+    o = Ref{Ptr{Int8}}()
+    xgbcall(XGBoosterSaveModelToBuffer, b.handle, cfg, olen, o)
+    unsafe_wrap(Array, convert(Ptr{UInt8}, o[]), olen[])
 end
 save(b::Booster, io::IO; kw...) = write(io, save(b, Vector{UInt8}; kw...))
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -133,7 +133,7 @@ end
     dtrain = XGBoost.load(DMatrix, testfilepath("agaricus.txt.train"))
     dtest = XGBoost.load(DMatrix, testfilepath("agaricus.txt.test"))
 
-    model_file = "test.xgb"
+    model_file, _ = mktemp()
 
     bst = xgboost(dtrain, num_round=5,
                   η=1.0, max_depth=2,


### PR DESCRIPTION
Added some testing to verify that the save/load/serialize functionality is working as expected. I am not sure the best way to compare if loading in a booster worked correctly other than comparing predictions.

This PR includes changes from https://github.com/dmlc/XGBoost.jl/pull/125, and the typo mentioned here https://github.com/dmlc/XGBoost.jl/issues/126