### PR TITLE
Fix errors in docs examples

### DIFF
--- a/src/dmatrix.jl
+++ b/src/dmatrix.jl
@@ -107,6 +107,7 @@ function setinfo!(dm::DMatrix, name::AbstractString, info::AbstractVector)
     _setinfo!(dm, name, info)
 end
 setinfo!(dm::DMatrix, name::Symbol, info) = setinfo!(dm, string(name), info)
+setlabel!(dm::DMatrix, info::AbstractVector) = setinfo!(dm, "label", info)
 
 """
     setinfos!(dm::DMatrix; kw...)
@@ -218,7 +219,8 @@ Base.getindex(dm::DMatrix, idx::AbstractVector{<:Integer}, ::Colon; kw...) = sli
 
 DMatrix(X::AbstractMatrix, y::AbstractVector; kw...) = DMatrix(X; label=y, kw...)
 
-DMatrix(Xy::DataTuple; kw...) = DMatrix(Xy[1], Xy[2]; kw...)
+# X can be an abstract matrix or table
+DMatrix(Xy::Tuple{Any,AbstractVector}; kw...) = DMatrix(Xy[1], Xy[2]; kw...)
 
 DMatrix(dm::DMatrix) = dm
 
@@ -233,6 +235,10 @@ function DMatrix(tbl;
 end
 
 DMatrix(tbl, y::AbstractVector; kw...) = DMatrix(tbl; label=y, kw...)
+function DMatrix(tbl, y_col::Symbol; kw...) 
+    X_cols = [i for i in Tables.columnnames(tbl) if i!=y_col]
+    return DMatrix(tbl[!, X_cols]; label=tbl[!, y_col], kw...)
+end
 
 """
     nrows(dm::DMatrix)


### PR DESCRIPTION
1. Modify `DMatrix` to accept a generic tuple of 2 instead of a `DataTuple`
I set the type to `Tuple{Any,AbstractVector}`, because we want a tuple of 2 items, and the second item has to be an abstract vector. I am not sure if we want this or just a generic tuple. This error was mentioned [here](https://github.com/dmlc/XGBoost.jl/issues/123#issuecomment-1303541408)
```julia
DMatrix(Xy::Tuple{Any,AbstractVector}; kw...) = DMatrix(Xy[1], Xy[2]; kw...)
```

2. Added a function for setting the value of the label in a `DMatrix`. Usage was in the docs, but I could not find this function. 
```julia
setlabel!(dm::DMatrix, info::AbstractVector) = setinfo!(dm, "label", info)
```

3. Added functionality for instantiating a `DMatrix` with a table and symbol for the label. This was also in the docs, but it did not work. 
```julia
DMatrix(df, :y)  # equivalent to DMatrix(df, y)
```