### PR TITLE
make DMatrix constructors more permissive to accommodate table arguments

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "XGBoost"
 uuid = "009559a3-9522-5dbb-924b-0b6ed2b22bb9"
-version = "2.0.1"
+version = "2.0.2"
 
 [deps]
 AbstractTrees = "1520ce14-60c1-5f80-bbc7-55ef81b5835c"

--- a/docs/src/api.md
+++ b/docs/src/api.md
@@ -16,6 +16,7 @@ setfeaturenames!
 getfeaturenames
 setinfo!
 setinfos!
+setlabel!
 getinfo
 slice
 nrows

--- a/src/XGBoost.jl
+++ b/src/XGBoost.jl
@@ -20,13 +20,11 @@ using .Lib
 using .Lib: DMatrixHandle, BoosterHandle
 
 
-const DataTuple = Tuple{AbstractMatrix,AbstractVector}
-
-
 include("dmatrix.jl")
 include("booster.jl")
 include("introspection.jl")
 include("show.jl")
 include("defaultparams.jl")
+
 
 end # module XGBoost

--- a/src/dmatrix.jl
+++ b/src/dmatrix.jl
@@ -41,7 +41,7 @@ DMatrix(tbl, yname::Symbol; kw...)
     If data is passed in tabular form feature names will be set automatically but can
     be overriden with the keyword argument.
 - `yname`: If passed a tabular argument `tbl`, `yname` is the name of the column which holds the
-    label data.
+    label data.  It will automatically be omitted from the features.
 
 ### Keyword Arguments
 - `missing_value`: The `Float32` value of elements of input data to be interpreted as `missing`,
@@ -233,6 +233,12 @@ function DMatrix(tbl;
 end
 
 DMatrix(tbl, y::AbstractVector; kw...) = DMatrix(tbl; label=y, kw...)
+
+function DMatrix(tbl, ycol::Symbol; kw...)
+    Xcols = [n for n ∈ Tables.columnnames(tbl) if n ≠ ycol]
+    tbl′ = NamedTuple(n=>Tables.getcolumn(tbl, n) for n ∈ Xcols)
+    DMatrix(tbl′, Tables.getcolumn(tbl, ycol); kw...)
+end
 
 """
     nrows(dm::DMatrix)

--- a/src/dmatrix.jl
+++ b/src/dmatrix.jl
@@ -109,6 +109,13 @@ end
 setinfo!(dm::DMatrix, name::Symbol, info) = setinfo!(dm, string(name), info)
 
 """
+    setlabel!(dm::DMatrix, y)
+
+Set the label data of `dm` to `y`.  Equivalent to `setinfo!(dm, "label", y)`.
+"""
+setlabel!(dm::DMatrix, info::AbstractVector) = setinfo!(dm, "label", info)
+
+"""
     setinfos!(dm::DMatrix; kw...)
 
 Make arbitrarily many calls to [`setinfo!`](@ref) via keyword arguments.  This function is called by all

--- a/src/dmatrix.jl
+++ b/src/dmatrix.jl
@@ -218,7 +218,7 @@ Base.getindex(dm::DMatrix, idx::AbstractVector{<:Integer}, ::Colon; kw...) = sli
 
 DMatrix(X::AbstractMatrix, y::AbstractVector; kw...) = DMatrix(X; label=y, kw...)
 
-DMatrix(Xy::DataTuple; kw...) = DMatrix(Xy[1], Xy[2]; kw...)
+DMatrix(Xy::Tuple; kw...) = DMatrix(Xy[1], Xy[2]; kw...)
 
 DMatrix(dm::DMatrix) = dm
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -55,6 +55,11 @@ include("utils.jl")
     dm = XGBoost.DMatrix((tbl, y))
     @test size(dm) == (10,2)
     @test XGBoost.getlabel(dm) ≈ y
+
+    tbl = (a=randn(10), b=randn(10), c=randn(Float32, 10))
+    dm = XGBoost.DMatrix(tbl, :c)
+    @test size(dm) == (10,2)
+    @test XGBoost.getlabel(dm) ≈ tbl.c
 end
 
 @testset "DMatrix IO" begin

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -49,6 +49,12 @@ include("utils.jl")
     dm = XGBoost.fromiterator(DMatrix, itr)
     @test size(dm) == (6, 2)
     @test XGBoost.getlabel(dm) ≈ 1:6
+
+    tbl = (a=randn(10), b=randn(10))
+    y = randn(Float32, 10)
+    dm = XGBoost.DMatrix((tbl, y))
+    @test size(dm) == (10,2)
+    @test XGBoost.getlabel(dm) ≈ y
 end
 
 @testset "DMatrix IO" begin


### PR DESCRIPTION
This is a more aggressive version of #129.

I got rid of the `DataTuple` alias altogether as it was not doing anything at this point.  It was probably left over from an earlier draft of my big PR.  Users are now responsible for making sure tuple types are correct.  Also added a test case for an example like the one in the docs.