### PR TITLE
Fix `importance` when no features are used

### DIFF
--- a/src/introspection.jl
+++ b/src/introspection.jl
@@ -57,7 +57,7 @@ function importance(b::Booster, type::AbstractString="gain")
     p = sortperm(fim, by=sum, rev=true)
 
     fns = _parse_out_feature_name.(names[p])
-    if length(b.feature_names) ≥ maximum(fns)
+    if length(b.feature_names) ≥ maximum(fns, init=0)
         fns = map(j -> b.feature_names[j], fns)
     end
 


### PR DESCRIPTION
In updating some code to v2, I ran into cases where a booster ended up as a null model and then `importance` would fail because `fns` here was empty.