### PR TITLE
DMatrix is now an AbstractMatrix

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "XGBoost"
 uuid = "009559a3-9522-5dbb-924b-0b6ed2b22bb9"
-version = "2.0.2"
+version = "2.1.0"
 
 [deps]
 AbstractTrees = "1520ce14-60c1-5f80-bbc7-55ef81b5835c"
@@ -9,6 +9,7 @@ JSON3 = "0f8b85d8-7281-11e9-16c2-39a750bddbf1"
 LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
 OrderedCollections = "bac558e1-5e72-5ebc-8fee-abe8a469f55d"
 SparseArrays = "2f01184e-e22b-5df5-ae63-d93ebab69eaf"
+SparseMatricesCSR = "a0a7dd2c-ebf4-11e9-1f05-cf50bc540ca1"
 Statistics = "10745b16-79ce-11e8-11f9-7d13ad32a3b2"
 Tables = "bd369af6-aec1-5ad0-b16a-f7cc5008161c"
 Term = "22787eb5-b846-44ae-b979-8e399b8463ab"
@@ -16,13 +17,14 @@ Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 XGBoost_jll = "a5c6f535-4255-5ca2-a466-0e519f119c46"
 
 [compat]
-JSON3 = "1"
 AbstractTrees = "0.4"
 CEnum = "0.4"
+JSON3 = "1"
+OrderedCollections = "1"
+SparseMatricesCSR = "0.6"
 Tables = "1"
 Term = "1"
-OrderedCollections = "1"
-XGBoost_jll = "1.5.2"
+XGBoost_jll = "1.7"
 julia = "1.6"
 
 [extras]

--- a/src/Lib.jl
+++ b/src/Lib.jl
@@ -47,6 +47,7 @@ function XGBuildInfo(out)
     @ccall libxgboost.XGBuildInfo(out::Ptr{Ptr{Cchar}})::Cint
 end
 
+# no prototype is found for this function at c_api.h:84:21, please use with caution
 function XGBGetLastError()
     @ccall libxgboost.XGBGetLastError()::Ptr{Cchar}
 end
@@ -55,12 +56,12 @@ function XGBRegisterLogCallback(callback)
     @ccall libxgboost.XGBRegisterLogCallback(callback::Ptr{Cvoid})::Cint
 end
 
-function XGBSetGlobalConfig(json_str)
-    @ccall libxgboost.XGBSetGlobalConfig(json_str::Ptr{Cchar})::Cint
+function XGBSetGlobalConfig(config)
+    @ccall libxgboost.XGBSetGlobalConfig(config::Ptr{Cchar})::Cint
 end
 
-function XGBGetGlobalConfig(json_str)
-    @ccall libxgboost.XGBGetGlobalConfig(json_str::Ptr{Ptr{Cchar}})::Cint
+function XGBGetGlobalConfig(out_config)
+    @ccall libxgboost.XGBGetGlobalConfig(out_config::Ptr{Ptr{Cchar}})::Cint
 end
 
 function XGDMatrixCreateFromFile(fname, silent, out)
@@ -71,12 +72,12 @@ function XGDMatrixCreateFromCSREx(indptr, indices, data, nindptr, nelem, num_col
     @ccall libxgboost.XGDMatrixCreateFromCSREx(indptr::Ptr{Csize_t}, indices::Ptr{Cuint}, data::Ptr{Cfloat}, nindptr::Csize_t, nelem::Csize_t, num_col::Csize_t, out::Ptr{DMatrixHandle})::Cint
 end
 
-function XGDMatrixCreateFromCSR(indptr, indices, data, ncol, json_config, out)
-    @ccall libxgboost.XGDMatrixCreateFromCSR(indptr::Ptr{Cchar}, indices::Ptr{Cchar}, data::Ptr{Cchar}, ncol::bst_ulong, json_config::Ptr{Cchar}, out::Ptr{DMatrixHandle})::Cint
+function XGDMatrixCreateFromCSR(indptr, indices, data, ncol, config, out)
+    @ccall libxgboost.XGDMatrixCreateFromCSR(indptr::Ptr{Cchar}, indices::Ptr{Cchar}, data::Ptr{Cchar}, ncol::bst_ulong, config::Ptr{Cchar}, out::Ptr{DMatrixHandle})::Cint
 end
 
-function XGDMatrixCreateFromDense(data, json_config, out)
-    @ccall libxgboost.XGDMatrixCreateFromDense(data::Ptr{Cchar}, json_config::Ptr{Cchar}, out::Ptr{DMatrixHandle})::Cint
+function XGDMatrixCreateFromDense(data, config, out)
+    @ccall libxgboost.XGDMatrixCreateFromDense(data::Ptr{Cchar}, config::Ptr{Cchar}, out::Ptr{DMatrixHandle})::Cint
 end
 
 function XGDMatrixCreateFromCSCEx(col_ptr, indices, data, nindptr, nelem, num_row, out)
@@ -95,12 +96,12 @@ function XGDMatrixCreateFromDT(data, feature_stypes, nrow, ncol, out, nthread)
     @ccall libxgboost.XGDMatrixCreateFromDT(data::Ptr{Ptr{Cvoid}}, feature_stypes::Ptr{Ptr{Cchar}}, nrow::bst_ulong, ncol::bst_ulong, out::Ptr{DMatrixHandle}, nthread::Cint)::Cint
 end
 
-function XGDMatrixCreateFromCudaColumnar(data, json_config, out)
-    @ccall libxgboost.XGDMatrixCreateFromCudaColumnar(data::Ptr{Cchar}, json_config::Ptr{Cchar}, out::Ptr{DMatrixHandle})::Cint
+function XGDMatrixCreateFromCudaColumnar(data, config, out)
+    @ccall libxgboost.XGDMatrixCreateFromCudaColumnar(data::Ptr{Cchar}, config::Ptr{Cchar}, out::Ptr{DMatrixHandle})::Cint
 end
 
-function XGDMatrixCreateFromCudaArrayInterface(data, json_config, out)
-    @ccall libxgboost.XGDMatrixCreateFromCudaArrayInterface(data::Ptr{Cchar}, json_config::Ptr{Cchar}, out::Ptr{DMatrixHandle})::Cint
+function XGDMatrixCreateFromCudaArrayInterface(data, config, out)
+    @ccall libxgboost.XGDMatrixCreateFromCudaArrayInterface(data::Ptr{Cchar}, config::Ptr{Cchar}, out::Ptr{DMatrixHandle})::Cint
 end
 
 const DataIterHandle = Ptr{Cvoid}
@@ -137,8 +138,12 @@ const XGDMatrixCallbackNext = Cvoid
 # typedef void DataIterResetCallback ( DataIterHandle handle )
 const DataIterResetCallback = Cvoid
 
-function XGDMatrixCreateFromCallback(iter, proxy, reset, next, c_json_config, out)
-    @ccall libxgboost.XGDMatrixCreateFromCallback(iter::DataIterHandle, proxy::DMatrixHandle, reset::Ptr{Cvoid}, next::Ptr{Cvoid}, c_json_config::Ptr{Cchar}, out::Ptr{DMatrixHandle})::Cint
+function XGDMatrixCreateFromCallback(iter, proxy, reset, next, config, out)
+    @ccall libxgboost.XGDMatrixCreateFromCallback(iter::DataIterHandle, proxy::DMatrixHandle, reset::Ptr{Cvoid}, next::Ptr{Cvoid}, config::Ptr{Cchar}, out::Ptr{DMatrixHandle})::Cint
+end
+
+function XGQuantileDMatrixCreateFromCallback(iter, proxy, ref, reset, next, config, out)
+    @ccall libxgboost.XGQuantileDMatrixCreateFromCallback(iter::DataIterHandle, proxy::DMatrixHandle, ref::DataIterHandle, reset::Ptr{Cvoid}, next::Ptr{Cvoid}, config::Ptr{Cchar}, out::Ptr{DMatrixHandle})::Cint
 end
 
 function XGDeviceQuantileDMatrixCreateFromCallback(iter, proxy, reset, next, missing, nthread, max_bin, out)
@@ -165,8 +170,8 @@ function XGImportArrowRecordBatch(data_handle, ptr_array, ptr_schema)
     @ccall libxgboost.XGImportArrowRecordBatch(data_handle::DataIterHandle, ptr_array::Ptr{Cvoid}, ptr_schema::Ptr{Cvoid})::Cint
 end
 
-function XGDMatrixCreateFromArrowCallback(next, json_config, out)
-    @ccall libxgboost.XGDMatrixCreateFromArrowCallback(next::Ptr{Cvoid}, json_config::Ptr{Cchar}, out::Ptr{DMatrixHandle})::Cint
+function XGDMatrixCreateFromArrowCallback(next, config, out)
+    @ccall libxgboost.XGDMatrixCreateFromArrowCallback(next::Ptr{Cvoid}, config::Ptr{Cchar}, out::Ptr{DMatrixHandle})::Cint
 end
 
 function XGDMatrixSliceDMatrix(handle, idxset, len, out)
@@ -229,6 +234,14 @@ function XGDMatrixNumCol(handle, out)
     @ccall libxgboost.XGDMatrixNumCol(handle::DMatrixHandle, out::Ptr{bst_ulong})::Cint
 end
 
+function XGDMatrixNumNonMissing(handle, out)
+    @ccall libxgboost.XGDMatrixNumNonMissing(handle::DMatrixHandle, out::Ptr{bst_ulong})::Cint
+end
+
+function XGDMatrixGetDataAsCSR(handle, config, out_indptr, out_indices, out_data)
+    @ccall libxgboost.XGDMatrixGetDataAsCSR(handle::DMatrixHandle, config::Ptr{Cchar}, out_indptr::Ptr{bst_ulong}, out_indices::Ptr{Cuint}, out_data::Ptr{Cfloat})::Cint
+end
+
 function XGBoosterCreate(dmats, len, out)
     @ccall libxgboost.XGBoosterCreate(dmats::Ptr{DMatrixHandle}, len::bst_ulong, out::Ptr{BoosterHandle})::Cint
 end
@@ -269,24 +282,24 @@ function XGBoosterPredict(handle, dmat, option_mask, ntree_limit, training, out_
     @ccall libxgboost.XGBoosterPredict(handle::BoosterHandle, dmat::DMatrixHandle, option_mask::Cint, ntree_limit::Cuint, training::Cint, out_len::Ptr{bst_ulong}, out_result::Ptr{Ptr{Cfloat}})::Cint
 end
 
-function XGBoosterPredictFromDMatrix(handle, dmat, c_json_config, out_shape, out_dim, out_result)
-    @ccall libxgboost.XGBoosterPredictFromDMatrix(handle::BoosterHandle, dmat::DMatrixHandle, c_json_config::Ptr{Cchar}, out_shape::Ptr{Ptr{bst_ulong}}, out_dim::Ptr{bst_ulong}, out_result::Ptr{Ptr{Cfloat}})::Cint
+function XGBoosterPredictFromDMatrix(handle, dmat, config, out_shape, out_dim, out_result)
+    @ccall libxgboost.XGBoosterPredictFromDMatrix(handle::BoosterHandle, dmat::DMatrixHandle, config::Ptr{Cchar}, out_shape::Ptr{Ptr{bst_ulong}}, out_dim::Ptr{bst_ulong}, out_result::Ptr{Ptr{Cfloat}})::Cint
 end
 
-function XGBoosterPredictFromDense(handle, values, c_json_config, m, out_shape, out_dim, out_result)
-    @ccall libxgboost.XGBoosterPredictFromDense(handle::BoosterHandle, values::Ptr{Cchar}, c_json_config::Ptr{Cchar}, m::DMatrixHandle, out_shape::Ptr{Ptr{bst_ulong}}, out_dim::Ptr{bst_ulong}, out_result::Ptr{Ptr{Cfloat}})::Cint
+function XGBoosterPredictFromDense(handle, values, config, m, out_shape, out_dim, out_result)
+    @ccall libxgboost.XGBoosterPredictFromDense(handle::BoosterHandle, values::Ptr{Cchar}, config::Ptr{Cchar}, m::DMatrixHandle, out_shape::Ptr{Ptr{bst_ulong}}, out_dim::Ptr{bst_ulong}, out_result::Ptr{Ptr{Cfloat}})::Cint
 end
 
-function XGBoosterPredictFromCSR(handle, indptr, indices, values, ncol, c_json_config, m, out_shape, out_dim, out_result)
-    @ccall libxgboost.XGBoosterPredictFromCSR(handle::BoosterHandle, indptr::Ptr{Cchar}, indices::Ptr{Cchar}, values::Ptr{Cchar}, ncol::bst_ulong, c_json_config::Ptr{Cchar}, m::DMatrixHandle, out_shape::Ptr{Ptr{bst_ulong}}, out_dim::Ptr{bst_ulong}, out_result::Ptr{Ptr{Cfloat}})::Cint
+function XGBoosterPredictFromCSR(handle, indptr, indices, values, ncol, config, m, out_shape, out_dim, out_result)
+    @ccall libxgboost.XGBoosterPredictFromCSR(handle::BoosterHandle, indptr::Ptr{Cchar}, indices::Ptr{Cchar}, values::Ptr{Cchar}, ncol::bst_ulong, config::Ptr{Cchar}, m::DMatrixHandle, out_shape::Ptr{Ptr{bst_ulong}}, out_dim::Ptr{bst_ulong}, out_result::Ptr{Ptr{Cfloat}})::Cint
 end
 
-function XGBoosterPredictFromCudaArray(handle, values, c_json_config, m, out_shape, out_dim, out_result)
-    @ccall libxgboost.XGBoosterPredictFromCudaArray(handle::BoosterHandle, values::Ptr{Cchar}, c_json_config::Ptr{Cchar}, m::DMatrixHandle, out_shape::Ptr{Ptr{bst_ulong}}, out_dim::Ptr{bst_ulong}, out_result::Ptr{Ptr{Cfloat}})::Cint
+function XGBoosterPredictFromCudaArray(handle, values, config, m, out_shape, out_dim, out_result)
+    @ccall libxgboost.XGBoosterPredictFromCudaArray(handle::BoosterHandle, values::Ptr{Cchar}, config::Ptr{Cchar}, m::DMatrixHandle, out_shape::Ptr{Ptr{bst_ulong}}, out_dim::Ptr{bst_ulong}, out_result::Ptr{Ptr{Cfloat}})::Cint
 end
 
-function XGBoosterPredictFromCudaColumnar(handle, values, c_json_config, m, out_shape, out_dim, out_result)
-    @ccall libxgboost.XGBoosterPredictFromCudaColumnar(handle::BoosterHandle, values::Ptr{Cchar}, c_json_config::Ptr{Cchar}, m::DMatrixHandle, out_shape::Ptr{Ptr{bst_ulong}}, out_dim::Ptr{bst_ulong}, out_result::Ptr{Ptr{Cfloat}})::Cint
+function XGBoosterPredictFromCudaColumnar(handle, values, config, m, out_shape, out_dim, out_result)
+    @ccall libxgboost.XGBoosterPredictFromCudaColumnar(handle::BoosterHandle, values::Ptr{Cchar}, config::Ptr{Cchar}, m::DMatrixHandle, out_shape::Ptr{Ptr{bst_ulong}}, out_dim::Ptr{bst_ulong}, out_result::Ptr{Ptr{Cfloat}})::Cint
 end
 
 function XGBoosterLoadModel(handle, fname)
@@ -301,8 +314,8 @@ function XGBoosterLoadModelFromBuffer(handle, buf, len)
     @ccall libxgboost.XGBoosterLoadModelFromBuffer(handle::BoosterHandle, buf::Ptr{Cvoid}, len::bst_ulong)::Cint
 end
 
-function XGBoosterSaveModelToBuffer(handle, json_config, out_len, out_dptr)
-    @ccall libxgboost.XGBoosterSaveModelToBuffer(handle::BoosterHandle, json_config::Ptr{Cchar}, out_len::Ptr{bst_ulong}, out_dptr::Ptr{Ptr{Cchar}})::Cint
+function XGBoosterSaveModelToBuffer(handle, config, out_len, out_dptr)
+    @ccall libxgboost.XGBoosterSaveModelToBuffer(handle::BoosterHandle, config::Ptr{Cchar}, out_len::Ptr{bst_ulong}, out_dptr::Ptr{Ptr{Cchar}})::Cint
 end
 
 function XGBoosterGetModelRaw(handle, out_len, out_dptr)
@@ -329,8 +342,8 @@ function XGBoosterSaveJsonConfig(handle, out_len, out_str)
     @ccall libxgboost.XGBoosterSaveJsonConfig(handle::BoosterHandle, out_len::Ptr{bst_ulong}, out_str::Ptr{Ptr{Cchar}})::Cint
 end
 
-function XGBoosterLoadJsonConfig(handle, json_parameters)
-    @ccall libxgboost.XGBoosterLoadJsonConfig(handle::BoosterHandle, json_parameters::Ptr{Cchar})::Cint
+function XGBoosterLoadJsonConfig(handle, config)
+    @ccall libxgboost.XGBoosterLoadJsonConfig(handle::BoosterHandle, config::Ptr{Cchar})::Cint
 end
 
 function XGBoosterDumpModel(handle, fmap, with_stats, out_len, out_dump_array)
@@ -369,8 +382,44 @@ function XGBoosterGetStrFeatureInfo(handle, field, len, out_features)
     @ccall libxgboost.XGBoosterGetStrFeatureInfo(handle::BoosterHandle, field::Ptr{Cchar}, len::Ptr{bst_ulong}, out_features::Ptr{Ptr{Ptr{Cchar}}})::Cint
 end
 
-function XGBoosterFeatureScore(handle, json_config, out_n_features, out_features, out_dim, out_shape, out_scores)
-    @ccall libxgboost.XGBoosterFeatureScore(handle::BoosterHandle, json_config::Ptr{Cchar}, out_n_features::Ptr{bst_ulong}, out_features::Ptr{Ptr{Ptr{Cchar}}}, out_dim::Ptr{bst_ulong}, out_shape::Ptr{Ptr{bst_ulong}}, out_scores::Ptr{Ptr{Cfloat}})::Cint
+function XGBoosterFeatureScore(handle, config, out_n_features, out_features, out_dim, out_shape, out_scores)
+    @ccall libxgboost.XGBoosterFeatureScore(handle::BoosterHandle, config::Ptr{Cchar}, out_n_features::Ptr{bst_ulong}, out_features::Ptr{Ptr{Ptr{Cchar}}}, out_dim::Ptr{bst_ulong}, out_shape::Ptr{Ptr{bst_ulong}}, out_scores::Ptr{Ptr{Cfloat}})::Cint
+end
+
+function XGCommunicatorInit(config)
+    @ccall libxgboost.XGCommunicatorInit(config::Ptr{Cchar})::Cint
+end
+
+function XGCommunicatorFinalize()
+    @ccall libxgboost.XGCommunicatorFinalize()::Cint
+end
+
+function XGCommunicatorGetRank()
+    @ccall libxgboost.XGCommunicatorGetRank()::Cint
+end
+
+function XGCommunicatorGetWorldSize()
+    @ccall libxgboost.XGCommunicatorGetWorldSize()::Cint
+end
+
+function XGCommunicatorIsDistributed()
+    @ccall libxgboost.XGCommunicatorIsDistributed()::Cint
+end
+
+function XGCommunicatorPrint(message)
+    @ccall libxgboost.XGCommunicatorPrint(message::Ptr{Cchar})::Cint
+end
+
+function XGCommunicatorGetProcessorName(name_str)
+    @ccall libxgboost.XGCommunicatorGetProcessorName(name_str::Ptr{Ptr{Cchar}})::Cint
+end
+
+function XGCommunicatorBroadcast(send_receive_buffer, size, root)
+    @ccall libxgboost.XGCommunicatorBroadcast(send_receive_buffer::Ptr{Cvoid}, size::Csize_t, root::Cint)::Cint
+end
+
+function XGCommunicatorAllreduce(send_receive_buffer, count, data_type, op)
+    @ccall libxgboost.XGCommunicatorAllreduce(send_receive_buffer::Ptr{Cvoid}, count::Csize_t, data_type::Cint, op::Cint)::Cint
 end
 
 # Skipping MacroDefinition: XGB_DLL XGB_EXTERN_C __attribute__ ( ( visibility ( "default" ) ) )

--- a/src/XGBoost.jl
+++ b/src/XGBoost.jl
@@ -1,13 +1,18 @@
 module XGBoost
 
 using LinearAlgebra
+import SparseArrays
 using SparseArrays: SparseMatrixCSC, nnz
+import SparseMatricesCSR
+using SparseMatricesCSR: SparseMatrixCSR
 using AbstractTrees
 using OrderedCollections
 using JSON3
 using Tables
 using Term
 using Statistics: mean, std
+
+using Base: @propagate_inbounds
 
 using Base.Iterators: Stateful, reset!
 

--- a/src/show.jl
+++ b/src/show.jl
@@ -14,8 +14,13 @@ function _features_display_string(fs, n)
 end
 
 function Base.show(io::IO, mime::MIME"text/plain", dm::DMatrix)
+    str = if !hasdata(dm)
+        "{dim}(values not allocated){/dim}"
+    else
+        sprint((io, x) -> show(io, MIME"text/plain"(), x), dm.data)
+    end
     p = Panel(_features_display_string(getfeaturenames(dm), size(dm,2)),
-              "{dim}(opaque object){/dim}",
+              str,
               style="magenta",
               title="XGBoost.DMatrix",
               title_style="bold cyan",

--- a/src/show.jl
+++ b/src/show.jl
@@ -17,7 +17,9 @@ function Base.show(io::IO, mime::MIME"text/plain", dm::DMatrix)
     str = if !hasdata(dm)
         "{dim}(values not allocated){/dim}"
     else
-        sprint((io, x) -> show(io, MIME"text/plain"(), x), dm.data)
+        sprint((io, x) -> show(io, MIME"text/plain"(), x), dm.data,
+               context=:compact=>true,
+              )
     end
     p = Panel(_features_display_string(getfeaturenames(dm), size(dm,2)),
               str,

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -6,29 +6,38 @@ include("utils.jl")
 
 @testset "XGBoost" begin
 
-# it's *very* hard to do real tests here because we can't get data back
-# this section just checks for errors, only training below can verify it's working properly
+# note that non-Float32 matrices will get truncated and `==` may not hold
 @testset "DMatrix Constructors" begin
-    dm = DMatrix(randn(10,3))
+    X = randn(Float32, 10, 3)
+    dm = DMatrix(X)
     @test size(dm) == (10,3)
+    @test !XGBoost.hasdata(dm)
+    @test dm == X
 
-    dm = DMatrix(transpose(randn(4,5)))
+    X = transpose(randn(Float32, 4, 5))
+    dm = DMatrix(X)
     @test (size(dm,1), size(dm,2)) == (5,4)
+    @test dm == X
 
-    dm = DMatrix(randn(4,5)')
+    X = randn(Float32, 4, 5)'
+    dm = DMatrix(X)
     @test size(dm) == (5,4)
+    @test dm == X
 
-    dm = DMatrix(sprand(100, 10, 0.1))
-    @test size(dm) == (100,10)
+    X = sprand(Float32, 100, 10, 0.1)
+    dm = DMatrix(X)
+    @test dm == X
 
+    #TODO: what??? see https://github.com/dmlc/xgboost/issues/8459
     dm = DMatrix([1 2 missing
                   3 missing 4
                   5 6 7
                   missing missing missing])
     @test size(dm) == (4,3)
 
-    dm = DMatrix(transpose(sprand(100, 10, 0.1)))
-    @test size(dm) == (10,100)
+    X = transpose(sprand(Float32, 100, 10, 0.1))
+    dm = DMatrix(X)
+    @test X == dm
 
     dm = DMatrix(randn(3,2), Float32[1.0, 2.0, 3.0])
     @test XGBoost.getlabel(dm) == Float32[1.0, 2.0, 3.0]

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -28,12 +28,12 @@ include("utils.jl")
     dm = DMatrix(X)
     @test dm == X
 
-    #TODO: what??? see https://github.com/dmlc/xgboost/issues/8459
-    dm = DMatrix([1 2 missing
-                  3 missing 4
-                  5 6 7
-                  missing missing missing])
-    @test size(dm) == (4,3)
+    X = [1 2 missing
+         3 missing 4
+         5 6 7
+         missing missing missing]
+    dm = DMatrix(X)
+    @test isequal(X, dm)
 
     X = transpose(sprand(Float32, 100, 10, 0.1))
     dm = DMatrix(X)
@@ -170,7 +170,7 @@ end
     bst2 = Booster(DMatrix[])
     XGBoost.load!(bst2, open(model_file))
     @test preds == predict(bst2, dtest)
-    
+
     bst2 = XGBoost.load(Booster, model_file)
     @test preds == predict(bst2, dtest)
 


### PR DESCRIPTION
This is added by virtue of the new `XGDMatrixGetDataCSR` method in libxgboost 1.7 which is now required.  Unit tests for `DMatrix` constructors have been vastly improved as they now check that the matrices were actually constructed correctly rather than merely having the same shape.

The behavior I'm seeing in the presence of null values doesn't make sense to me, so [this issue](https://github.com/dmlc/xgboost/issues/8459) is going to have to be resolved before this gets merged.