### PR TITLE
Display split conditions for all nodes in Term.Tree

### DIFF
--- a/src/show.jl
+++ b/src/show.jl
@@ -90,17 +90,20 @@ function importancereport(b::Booster)
     end
 end
 
-function _tree_display_branch_string(split, j::Integer)
-    o = "($j)"
-    isnothing(split) ? o : string(split, " ", o)
-end
-
-function _tree_display(node::Node)
-    ch = children(node)
-    if isempty(ch)
+function _tree_display(node::XGBoost.Node)
+    if length(node.children)==0
         sprint(show, node)
     else
-        OrderedDict(_tree_display_branch_string(ch[j].split, j)=>_tree_display(ch[j]) for j ∈ 1:length(ch))
+        dict = Dict()
+        foreach(node.children) do child
+            if node.yes == child.id
+                key = string(node.split, " < ", node.split_condition)
+            else
+                key = string(node.split, " >= ", node.split_condition)
+            end
+            dict[key] = _tree_display(child)
+        end
+        dict
     end
 end
 

--- a/src/show.jl
+++ b/src/show.jl
@@ -90,7 +90,7 @@ function importancereport(b::Booster)
     end
 end
 
-function _tree_display(node::XGBoost.Node)
+function _tree_display(node::Node)
     if length(node.children)==0
         sprint(show, node)
     else


### PR DESCRIPTION
Term.Tree() view is missing important information for every node, the split condition. Because the split condition is missing, the tree has almost no useful value. See the comparison of the old(top) and proposed(bottom) below:

![image](https://user-images.githubusercontent.com/16889318/207728441-52574376-7fee-4cc1-a1fc-532d08d2555a.png)

In the top, it is impossible to know how to navigate through the tree with values for x1 and x2, while it is possible on the bottom.

