### PR TITLE
validate parameter names by default

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "XGBoost"
 uuid = "009559a3-9522-5dbb-924b-0b6ed2b22bb9"
-version = "2.2.0"
+version = "2.2.1"
 
 [deps]
 AbstractTrees = "1520ce14-60c1-5f80-bbc7-55ef81b5835c"

--- a/src/XGBoost.jl
+++ b/src/XGBoost.jl
@@ -26,6 +26,23 @@ using .Lib
 using .Lib: DMatrixHandle, BoosterHandle
 
 
+const LOG_LEVEL_REGEX = r"\[.*\] (\D*): "
+
+function xgblog(s::Cstring)
+    s = unsafe_string(s)
+    m = match(LOG_LEVEL_REGEX, s)
+    if isnothing(m) || isempty(m.captures)
+        @info(s)
+    elseif m.captures[1] == "WARNING"
+        @warn(s)
+    else
+        @info(s)
+    end
+end
+
+__init__() = XGBRegisterLogCallback(@cfunction(xgblog, Nothing, (Cstring,)))
+
+
 include("dmatrix.jl")
 include("booster.jl")
 include("introspection.jl")

--- a/src/booster.jl
+++ b/src/booster.jl
@@ -93,6 +93,7 @@ function Booster(cache::AbstractVector{<:DMatrix};
                  model_buffer=UInt8[],
                  model_file::AbstractString="",
                  tree_method::Union{Nothing,AbstractString}=nothing,
+                 validate_parameters::Bool=true,
                  kw...
                 )
     o = Ref{BoosterHandle}()
@@ -109,7 +110,7 @@ function Booster(cache::AbstractVector{<:DMatrix};
     else
         (tree_method=tree_method,)
     end
-    setparams!(b; tm..., kw...)
+    setparams!(b; validate_parameters, tm..., kw...)
     b
 end
 Booster(dm::DMatrix; kw...) = Booster([dm]; kw...)


### PR DESCRIPTION
I don't really like changing the default parameters will-he nill-he but multiple of us have gotten pretty annoyed by this so this PR turns on warnings for invalid parameter names by default.

It suffers from the usual issue of having its own stderr output so we can't run it through the Julia logger.