### PR TITLE
add ability to set multi-valued booster params

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "XGBoost"
 uuid = "009559a3-9522-5dbb-924b-0b6ed2b22bb9"
-version = "2.2.2"
+version = "2.2.3"
 
 [deps]
 AbstractTrees = "1520ce14-60c1-5f80-bbc7-55ef81b5835c"

--- a/src/booster.jl
+++ b/src/booster.jl
@@ -81,6 +81,15 @@ end
 setparam!(b::Booster, name::AbstractString, val) = setparam!(b, name, string(val))
 setparam!(b::Booster, name::Symbol, val) = setparam!(b, string(name), val)
 
+setmultiparams!(b::Booster, name::Union{Symbol,AbstractString}, vals) = foreach(v -> setparam!(b, name, v), vals)
+
+# the API for some parameters involves multiple separate calls to XGBoosterSetParam
+# multi methods for resolving ambiguities
+setparam!(b::Booster, name::Symbol, vals::AbstractVector) = setmultiparams!(b, name, vals)
+setparam!(b::Booster, name::AbstractString, vals::AbstractVector) = setmultiparams!(b, name, vals)
+setparam!(b::Booster, name::Symbol, vals::Tuple) = setmultiparams!(b, name, vals)
+setparam!(b::Booster, name::AbstractString, vals::Tuple) = setmultiparams!(b, name, vals)
+
 """
     setparams!(b::Booster; kw...)
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -101,6 +101,8 @@ end
                 watchlist=watchlist,
                 η=1, max_depth=2,
                 objective="binary:logistic",
+                # check that we can set multiple param values
+                eval_metric=["rmse", "rmsle"],
                )
     end
 
@@ -171,6 +173,7 @@ end
                   η=1.0, max_depth=2,
                   objective="binary:logistic",
                   watchlist=Dict(),
+                  eval_metric=("mae", "mape"),
                  )
     preds = predict(bst, dtest)
     XGBoost.save(bst, model_file)


### PR DESCRIPTION
Prompted by #163 I discovered that the C API expects certain parameters to be set via multiple separate calls.  Currently the only way to do this is via multiple calls to `setparam!`.  This PR adds that ability to reproduce the same behavior with an `AbstractVector` or `Tuple`.