### PR TITLE
Revise predict to allow all 'type'

### DIFF
--- a/src/booster.jl
+++ b/src/booster.jl
@@ -322,7 +322,7 @@ function predict(b::Booster, Xy::DMatrix;
     oshape = Ref{Ptr{UInt64}}()
     odim = Ref{UInt64}()
     o = Ref{Ptr{Cfloat}}()
-    XGBoost.xgbcall(XGBoost.XGBoosterPredictFromDMatrix, b.handle, Xy.handle, opts, oshape, odim, o)
+    xgbcall(XGBoosterPredictFromDMatrix, b.handle, Xy.handle, opts, oshape, odim, o)
     dims = reverse(unsafe_wrap(Array, oshape[], odim[]))
     o = unsafe_wrap(Array, o[], tuple(dims...))
     length(dims) > 1 ? permutedims(o, reverse(1:ndims(o))) : o

--- a/src/booster.jl
+++ b/src/booster.jl
@@ -277,7 +277,7 @@ end
 
 
 """
-    predict(b::Booster, data; margin=false, training=false, ntree_limit=0)
+    predict(b::Booster, data; type=0, training=false, ntree_limit=0)
 
 Use the model `b` to run predictions on `data`.  This will return a `Vector{Float32}` which can be compared
 to training or test target data.

--- a/src/booster.jl
+++ b/src/booster.jl
@@ -314,13 +314,13 @@ function predict(b::Booster, Xy::DMatrix;
         type=0
     end
     opts = Dict("type"=>type,
-    "iteration_begin"=>ntree_lower_limit,
-    "iteration_end"=>ntree_limit,
-    "strict_shape"=>false,
-    "training"=>training,
-    ) |> JSON3.write
-    oshape = Ref{Ptr{UInt64}}()
-    odim = Ref{UInt64}()
+                "iteration_begin"=>ntree_lower_limit,
+                "iteration_end"=>ntree_limit,
+                "strict_shape"=>false,
+                "training"=>training,
+                ) |> JSON3.write
+    oshape = Ref{Ptr{Lib.bst_ulong}}()
+    odim = Ref{Lib.bst_ulong}()
     o = Ref{Ptr{Cfloat}}()
     xgbcall(XGBoosterPredictFromDMatrix, b.handle, Xy.handle, opts, oshape, odim, o)
     dims = reverse(unsafe_wrap(Array, oshape[], odim[]))

--- a/src/booster.jl
+++ b/src/booster.jl
@@ -305,10 +305,10 @@ ŷ = predict(b, X)
 ```
 """
 function predict(b::Booster, Xy::DMatrix;
-                type::Integer=0,  # 0-normal, 1-margin, 2-contrib, 3-est. contrib,4-interact,5-est. interact, 6-leaf
-                training::Bool=false,
-                ntree_lower_limit::Integer=0,
-                ntree_limit::Integer=0,  # 0 corresponds to no limit
+                 type::Integer=0,  # 0-normal, 1-margin, 2-contrib, 3-est. contrib,4-interact,5-est. interact, 6-leaf
+                 training::Bool=false,
+                 ntree_lower_limit::Integer=0,
+                 ntree_limit::Integer=0,  # 0 corresponds to no limit
                 )
     if type<0 || type>6
         type=0

--- a/src/booster.jl
+++ b/src/booster.jl
@@ -305,11 +305,11 @@ ŷ = predict(b, X)
 ```
 """
 function predict(b::Booster, Xy::DMatrix;
-    type::Integer=0,  # 0-normal, 1-margin, 2-contrib, 3-est. contrib,4-interact,5-est. interact, 6-leaf
-    training::Bool=false,
-    ntree_lower_limit::Integer=0,
-    ntree_limit::Integer=0,  # 0 corresponds to no limit
-   )
+                type::Integer=0,  # 0-normal, 1-margin, 2-contrib, 3-est. contrib,4-interact,5-est. interact, 6-leaf
+                training::Bool=false,
+                ntree_lower_limit::Integer=0,
+                ntree_limit::Integer=0,  # 0 corresponds to no limit
+                )
     if type<0 || type>6
         type=0
     end
@@ -318,7 +318,7 @@ function predict(b::Booster, Xy::DMatrix;
                 "iteration_end"=>ntree_limit,
                 "strict_shape"=>false,
                 "training"=>training,
-                ) |> JSON3.write
+               ) |> JSON3.write
     oshape = Ref{Ptr{Lib.bst_ulong}}()
     odim = Ref{Lib.bst_ulong}()
     o = Ref{Ptr{Cfloat}}()


### PR DESCRIPTION
Theses changes would allow a user access to a feature of libxgboost that reports feature contributions and/or interactions on the record level. This can be useful for Shapley type analyses. The additional data is obtained via specification of the 'type' parameter in Lib.XGBoosterPredictFromDMatrix().

A 'type' parameter is added to predict(); Input values are 0 through 6. The meaning associated with each parameter value is added to the docstring. This is an optional parameter with a default of 0 which provides normal output.

Was not certain what to do with old parameter 'margin' - I removed it as is redundant to the 'type' specification although might cause issue if others have it in and code.

There is significant variation in the dimensions of data returned dependent on the 'type' and booster objective ( multi class objectives return and extra dimension). 'type' 2 and 3 return 2 dimension array. 'type' 4 and 5 return 3 dimensional array. transpose() fails on 3 dimensional array and is replaced with permutedims(). This creates a trade-off in that permutedims() reallocates memory for array although the Matrix Type is more robust than the Transpose Type. For normal prediction(i.e. 'type'=0 where return is vector), there is no additional allocation so this should not impact operations that call predict many times ( for the creation of learning curves/cross validation).

Bob