### PR TITLE
expand compat bounds for Term.jl

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -25,7 +25,7 @@ JSON3 = "1"
 OrderedCollections = "1"
 SparseMatricesCSR = "0.6"
 Tables = "1"
-Term = "1"
+Term = "1, 2"
 XGBoost_jll = "1.7.2"
 julia = "1.6"
 

--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "XGBoost"
 uuid = "009559a3-9522-5dbb-924b-0b6ed2b22bb9"
-version = "2.2.4"
+version = "2.2.5"
 
 [deps]
 AbstractTrees = "1520ce14-60c1-5f80-bbc7-55ef81b5835c"


### PR DESCRIPTION
At least in some cases tree display looks wonky with 2.0 but this may not be a new issue and I would not consider that "breaking".