### PR TITLE
fixes for Term extension

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "XGBoost"
 uuid = "009559a3-9522-5dbb-924b-0b6ed2b22bb9"
-version = "2.3.0"
+version = "2.3.1"
 
 [deps]
 AbstractTrees = "1520ce14-60c1-5f80-bbc7-55ef81b5835c"

--- a/src/dmatrix.jl
+++ b/src/dmatrix.jl
@@ -266,7 +266,7 @@ function DMatrix(tbl;
                  feature_names::Union{Nothing,AbstractVector{<:AbstractString}}=nothing,
                  kw...
                 )
-    cols = Tables.columns(tbl)
+    cols = Tables.Columns(tbl)
     if feature_names === nothing
         feature_names = [string(x) for x in Tables.columnnames(cols)]
     end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -164,6 +164,21 @@ end
     @test typeof(importancereport(bst)) <: Term.Tables.Table
 end
 
+# these just ensure we don't have any exceptions
+@testset "Term extension" begin
+    dtrain = XGBoost.load(DMatrix, testfilepath("agaricus.txt.train"))
+    dtest = XGBoost.load(DMatrix, testfilepath("agaricus.txt.test"))
+
+    bst = xgboost(dtrain, num_round=5,
+                  η=1.0, max_depth=2,
+                  objective="binary:logistic",
+                  watchlist=Dict(),
+                 )
+
+    @test Term.Panel(dtrain) isa Term.Panel
+    @test Term.Panel(bst) isa Term.Panel
+end
+
 @testset "Booster Save/Load/Serialize" begin
     dtrain = XGBoost.load(DMatrix, testfilepath("agaricus.txt.train"))
     dtest = XGBoost.load(DMatrix, testfilepath("agaricus.txt.test"))


### PR DESCRIPTION
Somehow I had previously missed the fact that the Term extension was no longer even creating `show` methods.  With this fix, Term panels will show for the `"text/plain"` mime type when Term is loaded.

Additionally, there is a small fix for CUDA-backed tables in an issue that's caught in a test but not in CI/CD because of lack of CUDA.