### PR TITLE
Separate XGBoost JLL package into CPU and GPU versions

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "XGBoost"
 uuid = "009559a3-9522-5dbb-924b-0b6ed2b22bb9"
-version = "2.5.1"
+version = "2.5.2"
 
 [deps]
 AbstractTrees = "1520ce14-60c1-5f80-bbc7-55ef81b5835c"
@@ -14,6 +14,7 @@ SparseMatricesCSR = "a0a7dd2c-ebf4-11e9-1f05-cf50bc540ca1"
 Statistics = "10745b16-79ce-11e8-11f9-7d13ad32a3b2"
 Tables = "bd369af6-aec1-5ad0-b16a-f7cc5008161c"
 Term = "22787eb5-b846-44ae-b979-8e399b8463ab"
+XGBoost_GPU_jll = "bf13095a-df47-5f5c-aa1a-d897479947cc"
 XGBoost_jll = "a5c6f535-4255-5ca2-a466-0e519f119c46"
 
 [weakdeps]
@@ -33,7 +34,8 @@ OrderedCollections = "1"
 SparseMatricesCSR = "0.6"
 Tables = "1"
 Term = "1, 2"
-XGBoost_jll = "2"
+XGBoost_jll = "2.1"
+XGBoost_GPU_jll = "2.1"
 julia = "1.6"
 
 [extras]

--- a/src/Lib.jl
+++ b/src/Lib.jl
@@ -7,10 +7,10 @@ using CEnum
 
 # only enable GPU support if there is a valid binary compatible with this system
 # should we place a warning here?
-if XGBoost_GPU_jll.is_available()
-    lib_xgboost = XGBoost_GPU_jll.libxgboost
+const libxgboost = @static if XGBoost_GPU_jll.is_available()
+    XGBoost_GPU_jll.libxgboost
 else
-    lib_xgboost = XGBoost_jll.libxgboost
+    XGBoost_jll.libxgboost
 end
 
 struct XGBoostError <: Exception
@@ -47,76 +47,76 @@ const DMatrixHandle = Ptr{Cvoid}
 const BoosterHandle = Ptr{Cvoid}
 
 function XGBoostVersion(major, minor, patch)
-    @ccall lib_xgboost.XGBoostVersion(major::Ptr{Cint}, minor::Ptr{Cint}, patch::Ptr{Cint})::Cvoid
+    @ccall libxgboost.XGBoostVersion(major::Ptr{Cint}, minor::Ptr{Cint}, patch::Ptr{Cint})::Cvoid
 end
 
 function XGBuildInfo(out)
-    @ccall lib_xgboost.XGBuildInfo(out::Ptr{Ptr{Cchar}})::Cint
+    @ccall libxgboost.XGBuildInfo(out::Ptr{Ptr{Cchar}})::Cint
 end
 
 # no prototype is found for this function at c_api.h:84:21, please use with caution
 function XGBGetLastError()
-    @ccall lib_xgboost.XGBGetLastError()::Ptr{Cchar}
+    @ccall libxgboost.XGBGetLastError()::Ptr{Cchar}
 end
 
 function XGBRegisterLogCallback(callback)
-    @ccall lib_xgboost.XGBRegisterLogCallback(callback::Ptr{Cvoid})::Cint
+    @ccall libxgboost.XGBRegisterLogCallback(callback::Ptr{Cvoid})::Cint
 end
 
 function XGBSetGlobalConfig(config)
-    @ccall lib_xgboost.XGBSetGlobalConfig(config::Ptr{Cchar})::Cint
+    @ccall libxgboost.XGBSetGlobalConfig(config::Ptr{Cchar})::Cint
 end
 
 function XGBGetGlobalConfig(out_config)
-    @ccall lib_xgboost.XGBGetGlobalConfig(out_config::Ptr{Ptr{Cchar}})::Cint
+    @ccall libxgboost.XGBGetGlobalConfig(out_config::Ptr{Ptr{Cchar}})::Cint
 end
 
 function XGDMatrixCreateFromFile(fname, silent, out)
-    @ccall lib_xgboost.XGDMatrixCreateFromFile(fname::Ptr{Cchar}, silent::Cint, out::Ptr{DMatrixHandle})::Cint
+    @ccall libxgboost.XGDMatrixCreateFromFile(fname::Ptr{Cchar}, silent::Cint, out::Ptr{DMatrixHandle})::Cint
 end
 
 function XGDMatrixCreateFromURI(config, out)
-    @ccall lib_xgboost.XGDMatrixCreateFromURI(config::Ptr{Cchar}, out::Ptr{DMatrixHandle})::Cint
+    @ccall libxgboost.XGDMatrixCreateFromURI(config::Ptr{Cchar}, out::Ptr{DMatrixHandle})::Cint
 end
 
 function XGDMatrixCreateFromCSREx(indptr, indices, data, nindptr, nelem, num_col, out)
-    @ccall lib_xgboost.XGDMatrixCreateFromCSREx(indptr::Ptr{Csize_t}, indices::Ptr{Cuint}, data::Ptr{Cfloat}, nindptr::Csize_t, nelem::Csize_t, num_col::Csize_t, out::Ptr{DMatrixHandle})::Cint
+    @ccall libxgboost.XGDMatrixCreateFromCSREx(indptr::Ptr{Csize_t}, indices::Ptr{Cuint}, data::Ptr{Cfloat}, nindptr::Csize_t, nelem::Csize_t, num_col::Csize_t, out::Ptr{DMatrixHandle})::Cint
 end
 
 function XGDMatrixCreateFromCSR(indptr, indices, data, ncol, config, out)
-    @ccall lib_xgboost.XGDMatrixCreateFromCSR(indptr::Ptr{Cchar}, indices::Ptr{Cchar}, data::Ptr{Cchar}, ncol::bst_ulong, config::Ptr{Cchar}, out::Ptr{DMatrixHandle})::Cint
+    @ccall libxgboost.XGDMatrixCreateFromCSR(indptr::Ptr{Cchar}, indices::Ptr{Cchar}, data::Ptr{Cchar}, ncol::bst_ulong, config::Ptr{Cchar}, out::Ptr{DMatrixHandle})::Cint
 end
 
 function XGDMatrixCreateFromDense(data, config, out)
-    @ccall lib_xgboost.XGDMatrixCreateFromDense(data::Ptr{Cchar}, config::Ptr{Cchar}, out::Ptr{DMatrixHandle})::Cint
+    @ccall libxgboost.XGDMatrixCreateFromDense(data::Ptr{Cchar}, config::Ptr{Cchar}, out::Ptr{DMatrixHandle})::Cint
 end
 
 function XGDMatrixCreateFromCSC(indptr, indices, data, nrow, config, out)
-    @ccall lib_xgboost.XGDMatrixCreateFromCSC(indptr::Ptr{Cchar}, indices::Ptr{Cchar}, data::Ptr{Cchar}, nrow::bst_ulong, config::Ptr{Cchar}, out::Ptr{DMatrixHandle})::Cint
+    @ccall libxgboost.XGDMatrixCreateFromCSC(indptr::Ptr{Cchar}, indices::Ptr{Cchar}, data::Ptr{Cchar}, nrow::bst_ulong, config::Ptr{Cchar}, out::Ptr{DMatrixHandle})::Cint
 end
 
 function XGDMatrixCreateFromCSCEx(col_ptr, indices, data, nindptr, nelem, num_row, out)
-    @ccall lib_xgboost.XGDMatrixCreateFromCSCEx(col_ptr::Ptr{Csize_t}, indices::Ptr{Cuint}, data::Ptr{Cfloat}, nindptr::Csize_t, nelem::Csize_t, num_row::Csize_t, out::Ptr{DMatrixHandle})::Cint
+    @ccall libxgboost.XGDMatrixCreateFromCSCEx(col_ptr::Ptr{Csize_t}, indices::Ptr{Cuint}, data::Ptr{Cfloat}, nindptr::Csize_t, nelem::Csize_t, num_row::Csize_t, out::Ptr{DMatrixHandle})::Cint
 end
 
 function XGDMatrixCreateFromMat(data, nrow, ncol, missing, out)
-    @ccall lib_xgboost.XGDMatrixCreateFromMat(data::Ptr{Cfloat}, nrow::bst_ulong, ncol::bst_ulong, missing::Cfloat, out::Ptr{DMatrixHandle})::Cint
+    @ccall libxgboost.XGDMatrixCreateFromMat(data::Ptr{Cfloat}, nrow::bst_ulong, ncol::bst_ulong, missing::Cfloat, out::Ptr{DMatrixHandle})::Cint
 end
 
 function XGDMatrixCreateFromMat_omp(data, nrow, ncol, missing, out, nthread)
-    @ccall lib_xgboost.XGDMatrixCreateFromMat_omp(data::Ptr{Cfloat}, nrow::bst_ulong, ncol::bst_ulong, missing::Cfloat, out::Ptr{DMatrixHandle}, nthread::Cint)::Cint
+    @ccall libxgboost.XGDMatrixCreateFromMat_omp(data::Ptr{Cfloat}, nrow::bst_ulong, ncol::bst_ulong, missing::Cfloat, out::Ptr{DMatrixHandle}, nthread::Cint)::Cint
 end
 
 function XGDMatrixCreateFromDT(data, feature_stypes, nrow, ncol, out, nthread)
-    @ccall lib_xgboost.XGDMatrixCreateFromDT(data::Ptr{Ptr{Cvoid}}, feature_stypes::Ptr{Ptr{Cchar}}, nrow::bst_ulong, ncol::bst_ulong, out::Ptr{DMatrixHandle}, nthread::Cint)::Cint
+    @ccall libxgboost.XGDMatrixCreateFromDT(data::Ptr{Ptr{Cvoid}}, feature_stypes::Ptr{Ptr{Cchar}}, nrow::bst_ulong, ncol::bst_ulong, out::Ptr{DMatrixHandle}, nthread::Cint)::Cint
 end
 
 function XGDMatrixCreateFromCudaColumnar(data, config, out)
-    @ccall lib_xgboost.XGDMatrixCreateFromCudaColumnar(data::Ptr{Cchar}, config::Ptr{Cchar}, out::Ptr{DMatrixHandle})::Cint
+    @ccall libxgboost.XGDMatrixCreateFromCudaColumnar(data::Ptr{Cchar}, config::Ptr{Cchar}, out::Ptr{DMatrixHandle})::Cint
 end
 
 function XGDMatrixCreateFromCudaArrayInterface(data, config, out)
-    @ccall lib_xgboost.XGDMatrixCreateFromCudaArrayInterface(data::Ptr{Cchar}, config::Ptr{Cchar}, out::Ptr{DMatrixHandle})::Cint
+    @ccall libxgboost.XGDMatrixCreateFromCudaArrayInterface(data::Ptr{Cchar}, config::Ptr{Cchar}, out::Ptr{DMatrixHandle})::Cint
 end
 
 const DataIterHandle = Ptr{Cvoid}
@@ -140,11 +140,11 @@ const XGBCallbackSetData = Cvoid
 const XGBCallbackDataIterNext = Cvoid
 
 function XGDMatrixCreateFromDataIter(data_handle, callback, cache_info, out)
-    @ccall lib_xgboost.XGDMatrixCreateFromDataIter(data_handle::DataIterHandle, callback::Ptr{XGBCallbackDataIterNext}, cache_info::Ptr{Cchar}, out::Ptr{DMatrixHandle})::Cint
+    @ccall libxgboost.XGDMatrixCreateFromDataIter(data_handle::DataIterHandle, callback::Ptr{XGBCallbackDataIterNext}, cache_info::Ptr{Cchar}, out::Ptr{DMatrixHandle})::Cint
 end
 
 function XGProxyDMatrixCreate(out)
-    @ccall lib_xgboost.XGProxyDMatrixCreate(out::Ptr{DMatrixHandle})::Cint
+    @ccall libxgboost.XGProxyDMatrixCreate(out::Ptr{DMatrixHandle})::Cint
 end
 
 # typedef int XGDMatrixCallbackNext ( DataIterHandle iter )
@@ -154,291 +154,291 @@ const XGDMatrixCallbackNext = Cvoid
 const DataIterResetCallback = Cvoid
 
 function XGDMatrixCreateFromCallback(iter, proxy, reset, next, config, out)
-    @ccall lib_xgboost.XGDMatrixCreateFromCallback(iter::DataIterHandle, proxy::DMatrixHandle, reset::Ptr{DataIterResetCallback}, next::Ptr{XGDMatrixCallbackNext}, config::Ptr{Cchar}, out::Ptr{DMatrixHandle})::Cint
+    @ccall libxgboost.XGDMatrixCreateFromCallback(iter::DataIterHandle, proxy::DMatrixHandle, reset::Ptr{DataIterResetCallback}, next::Ptr{XGDMatrixCallbackNext}, config::Ptr{Cchar}, out::Ptr{DMatrixHandle})::Cint
 end
 
 function XGQuantileDMatrixCreateFromCallback(iter, proxy, ref, reset, next, config, out)
-    @ccall lib_xgboost.XGQuantileDMatrixCreateFromCallback(iter::DataIterHandle, proxy::DMatrixHandle, ref::DataIterHandle, reset::Ptr{DataIterResetCallback}, next::Ptr{XGDMatrixCallbackNext}, config::Ptr{Cchar}, out::Ptr{DMatrixHandle})::Cint
+    @ccall libxgboost.XGQuantileDMatrixCreateFromCallback(iter::DataIterHandle, proxy::DMatrixHandle, ref::DataIterHandle, reset::Ptr{DataIterResetCallback}, next::Ptr{XGDMatrixCallbackNext}, config::Ptr{Cchar}, out::Ptr{DMatrixHandle})::Cint
 end
 
 function XGDeviceQuantileDMatrixCreateFromCallback(iter, proxy, reset, next, missing, nthread, max_bin, out)
-    @ccall lib_xgboost.XGDeviceQuantileDMatrixCreateFromCallback(iter::DataIterHandle, proxy::DMatrixHandle, reset::Ptr{DataIterResetCallback}, next::Ptr{XGDMatrixCallbackNext}, missing::Cfloat, nthread::Cint, max_bin::Cint, out::Ptr{DMatrixHandle})::Cint
+    @ccall libxgboost.XGDeviceQuantileDMatrixCreateFromCallback(iter::DataIterHandle, proxy::DMatrixHandle, reset::Ptr{DataIterResetCallback}, next::Ptr{XGDMatrixCallbackNext}, missing::Cfloat, nthread::Cint, max_bin::Cint, out::Ptr{DMatrixHandle})::Cint
 end
 
 function XGProxyDMatrixSetDataCudaArrayInterface(handle, c_interface_str)
-    @ccall lib_xgboost.XGProxyDMatrixSetDataCudaArrayInterface(handle::DMatrixHandle, c_interface_str::Ptr{Cchar})::Cint
+    @ccall libxgboost.XGProxyDMatrixSetDataCudaArrayInterface(handle::DMatrixHandle, c_interface_str::Ptr{Cchar})::Cint
 end
 
 function XGProxyDMatrixSetDataCudaColumnar(handle, c_interface_str)
-    @ccall lib_xgboost.XGProxyDMatrixSetDataCudaColumnar(handle::DMatrixHandle, c_interface_str::Ptr{Cchar})::Cint
+    @ccall libxgboost.XGProxyDMatrixSetDataCudaColumnar(handle::DMatrixHandle, c_interface_str::Ptr{Cchar})::Cint
 end
 
 function XGProxyDMatrixSetDataDense(handle, c_interface_str)
-    @ccall lib_xgboost.XGProxyDMatrixSetDataDense(handle::DMatrixHandle, c_interface_str::Ptr{Cchar})::Cint
+    @ccall libxgboost.XGProxyDMatrixSetDataDense(handle::DMatrixHandle, c_interface_str::Ptr{Cchar})::Cint
 end
 
 function XGProxyDMatrixSetDataCSR(handle, indptr, indices, data, ncol)
-    @ccall lib_xgboost.XGProxyDMatrixSetDataCSR(handle::DMatrixHandle, indptr::Ptr{Cchar}, indices::Ptr{Cchar}, data::Ptr{Cchar}, ncol::bst_ulong)::Cint
+    @ccall libxgboost.XGProxyDMatrixSetDataCSR(handle::DMatrixHandle, indptr::Ptr{Cchar}, indices::Ptr{Cchar}, data::Ptr{Cchar}, ncol::bst_ulong)::Cint
 end
 
 function XGImportArrowRecordBatch(data_handle, ptr_array, ptr_schema)
-    @ccall lib_xgboost.XGImportArrowRecordBatch(data_handle::DataIterHandle, ptr_array::Ptr{Cvoid}, ptr_schema::Ptr{Cvoid})::Cint
+    @ccall libxgboost.XGImportArrowRecordBatch(data_handle::DataIterHandle, ptr_array::Ptr{Cvoid}, ptr_schema::Ptr{Cvoid})::Cint
 end
 
 function XGDMatrixCreateFromArrowCallback(next, config, out)
-    @ccall lib_xgboost.XGDMatrixCreateFromArrowCallback(next::Ptr{XGDMatrixCallbackNext}, config::Ptr{Cchar}, out::Ptr{DMatrixHandle})::Cint
+    @ccall libxgboost.XGDMatrixCreateFromArrowCallback(next::Ptr{XGDMatrixCallbackNext}, config::Ptr{Cchar}, out::Ptr{DMatrixHandle})::Cint
 end
 
 function XGDMatrixSliceDMatrix(handle, idxset, len, out)
-    @ccall lib_xgboost.XGDMatrixSliceDMatrix(handle::DMatrixHandle, idxset::Ptr{Cint}, len::bst_ulong, out::Ptr{DMatrixHandle})::Cint
+    @ccall libxgboost.XGDMatrixSliceDMatrix(handle::DMatrixHandle, idxset::Ptr{Cint}, len::bst_ulong, out::Ptr{DMatrixHandle})::Cint
 end
 
 function XGDMatrixSliceDMatrixEx(handle, idxset, len, out, allow_groups)
-    @ccall lib_xgboost.XGDMatrixSliceDMatrixEx(handle::DMatrixHandle, idxset::Ptr{Cint}, len::bst_ulong, out::Ptr{DMatrixHandle}, allow_groups::Cint)::Cint
+    @ccall libxgboost.XGDMatrixSliceDMatrixEx(handle::DMatrixHandle, idxset::Ptr{Cint}, len::bst_ulong, out::Ptr{DMatrixHandle}, allow_groups::Cint)::Cint
 end
 
 function XGDMatrixFree(handle)
-    @ccall lib_xgboost.XGDMatrixFree(handle::DMatrixHandle)::Cint
+    @ccall libxgboost.XGDMatrixFree(handle::DMatrixHandle)::Cint
 end
 
 function XGDMatrixSaveBinary(handle, fname, silent)
-    @ccall lib_xgboost.XGDMatrixSaveBinary(handle::DMatrixHandle, fname::Ptr{Cchar}, silent::Cint)::Cint
+    @ccall libxgboost.XGDMatrixSaveBinary(handle::DMatrixHandle, fname::Ptr{Cchar}, silent::Cint)::Cint
 end
 
 function XGDMatrixSetInfoFromInterface(handle, field, c_interface_str)
-    @ccall lib_xgboost.XGDMatrixSetInfoFromInterface(handle::DMatrixHandle, field::Ptr{Cchar}, c_interface_str::Ptr{Cchar})::Cint
+    @ccall libxgboost.XGDMatrixSetInfoFromInterface(handle::DMatrixHandle, field::Ptr{Cchar}, c_interface_str::Ptr{Cchar})::Cint
 end
 
 function XGDMatrixSetFloatInfo(handle, field, array, len)
-    @ccall lib_xgboost.XGDMatrixSetFloatInfo(handle::DMatrixHandle, field::Ptr{Cchar}, array::Ptr{Cfloat}, len::bst_ulong)::Cint
+    @ccall libxgboost.XGDMatrixSetFloatInfo(handle::DMatrixHandle, field::Ptr{Cchar}, array::Ptr{Cfloat}, len::bst_ulong)::Cint
 end
 
 function XGDMatrixSetUIntInfo(handle, field, array, len)
-    @ccall lib_xgboost.XGDMatrixSetUIntInfo(handle::DMatrixHandle, field::Ptr{Cchar}, array::Ptr{Cuint}, len::bst_ulong)::Cint
+    @ccall libxgboost.XGDMatrixSetUIntInfo(handle::DMatrixHandle, field::Ptr{Cchar}, array::Ptr{Cuint}, len::bst_ulong)::Cint
 end
 
 function XGDMatrixSetStrFeatureInfo(handle, field, features, size)
-    @ccall lib_xgboost.XGDMatrixSetStrFeatureInfo(handle::DMatrixHandle, field::Ptr{Cchar}, features::Ptr{Ptr{Cchar}}, size::bst_ulong)::Cint
+    @ccall libxgboost.XGDMatrixSetStrFeatureInfo(handle::DMatrixHandle, field::Ptr{Cchar}, features::Ptr{Ptr{Cchar}}, size::bst_ulong)::Cint
 end
 
 function XGDMatrixGetStrFeatureInfo(handle, field, size, out_features)
-    @ccall lib_xgboost.XGDMatrixGetStrFeatureInfo(handle::DMatrixHandle, field::Ptr{Cchar}, size::Ptr{bst_ulong}, out_features::Ptr{Ptr{Ptr{Cchar}}})::Cint
+    @ccall libxgboost.XGDMatrixGetStrFeatureInfo(handle::DMatrixHandle, field::Ptr{Cchar}, size::Ptr{bst_ulong}, out_features::Ptr{Ptr{Ptr{Cchar}}})::Cint
 end
 
 function XGDMatrixSetDenseInfo(handle, field, data, size, type)
-    @ccall lib_xgboost.XGDMatrixSetDenseInfo(handle::DMatrixHandle, field::Ptr{Cchar}, data::Ptr{Cvoid}, size::bst_ulong, type::Cint)::Cint
+    @ccall libxgboost.XGDMatrixSetDenseInfo(handle::DMatrixHandle, field::Ptr{Cchar}, data::Ptr{Cvoid}, size::bst_ulong, type::Cint)::Cint
 end
 
 function XGDMatrixSetGroup(handle, group, len)
-    @ccall lib_xgboost.XGDMatrixSetGroup(handle::DMatrixHandle, group::Ptr{Cuint}, len::bst_ulong)::Cint
+    @ccall libxgboost.XGDMatrixSetGroup(handle::DMatrixHandle, group::Ptr{Cuint}, len::bst_ulong)::Cint
 end
 
 function XGDMatrixGetFloatInfo(handle, field, out_len, out_dptr)
-    @ccall lib_xgboost.XGDMatrixGetFloatInfo(handle::DMatrixHandle, field::Ptr{Cchar}, out_len::Ptr{bst_ulong}, out_dptr::Ptr{Ptr{Cfloat}})::Cint
+    @ccall libxgboost.XGDMatrixGetFloatInfo(handle::DMatrixHandle, field::Ptr{Cchar}, out_len::Ptr{bst_ulong}, out_dptr::Ptr{Ptr{Cfloat}})::Cint
 end
 
 function XGDMatrixGetUIntInfo(handle, field, out_len, out_dptr)
-    @ccall lib_xgboost.XGDMatrixGetUIntInfo(handle::DMatrixHandle, field::Ptr{Cchar}, out_len::Ptr{bst_ulong}, out_dptr::Ptr{Ptr{Cuint}})::Cint
+    @ccall libxgboost.XGDMatrixGetUIntInfo(handle::DMatrixHandle, field::Ptr{Cchar}, out_len::Ptr{bst_ulong}, out_dptr::Ptr{Ptr{Cuint}})::Cint
 end
 
 function XGDMatrixNumRow(handle, out)
-    @ccall lib_xgboost.XGDMatrixNumRow(handle::DMatrixHandle, out::Ptr{bst_ulong})::Cint
+    @ccall libxgboost.XGDMatrixNumRow(handle::DMatrixHandle, out::Ptr{bst_ulong})::Cint
 end
 
 function XGDMatrixNumCol(handle, out)
-    @ccall lib_xgboost.XGDMatrixNumCol(handle::DMatrixHandle, out::Ptr{bst_ulong})::Cint
+    @ccall libxgboost.XGDMatrixNumCol(handle::DMatrixHandle, out::Ptr{bst_ulong})::Cint
 end
 
 function XGDMatrixNumNonMissing(handle, out)
-    @ccall lib_xgboost.XGDMatrixNumNonMissing(handle::DMatrixHandle, out::Ptr{bst_ulong})::Cint
+    @ccall libxgboost.XGDMatrixNumNonMissing(handle::DMatrixHandle, out::Ptr{bst_ulong})::Cint
 end
 
 function XGDMatrixGetDataAsCSR(handle, config, out_indptr, out_indices, out_data)
-    @ccall lib_xgboost.XGDMatrixGetDataAsCSR(handle::DMatrixHandle, config::Ptr{Cchar}, out_indptr::Ptr{bst_ulong}, out_indices::Ptr{Cuint}, out_data::Ptr{Cfloat})::Cint
+    @ccall libxgboost.XGDMatrixGetDataAsCSR(handle::DMatrixHandle, config::Ptr{Cchar}, out_indptr::Ptr{bst_ulong}, out_indices::Ptr{Cuint}, out_data::Ptr{Cfloat})::Cint
 end
 
 function XGDMatrixGetQuantileCut(handle, config, out_indptr, out_data)
-    @ccall lib_xgboost.XGDMatrixGetQuantileCut(handle::DMatrixHandle, config::Ptr{Cchar}, out_indptr::Ptr{Ptr{Cchar}}, out_data::Ptr{Ptr{Cchar}})::Cint
+    @ccall libxgboost.XGDMatrixGetQuantileCut(handle::DMatrixHandle, config::Ptr{Cchar}, out_indptr::Ptr{Ptr{Cchar}}, out_data::Ptr{Ptr{Cchar}})::Cint
 end
 
 function XGBoosterCreate(dmats, len, out)
-    @ccall lib_xgboost.XGBoosterCreate(dmats::Ptr{DMatrixHandle}, len::bst_ulong, out::Ptr{BoosterHandle})::Cint
+    @ccall libxgboost.XGBoosterCreate(dmats::Ptr{DMatrixHandle}, len::bst_ulong, out::Ptr{BoosterHandle})::Cint
 end
 
 function XGBoosterFree(handle)
-    @ccall lib_xgboost.XGBoosterFree(handle::BoosterHandle)::Cint
+    @ccall libxgboost.XGBoosterFree(handle::BoosterHandle)::Cint
 end
 
 function XGBoosterSlice(handle, begin_layer, end_layer, step, out)
-    @ccall lib_xgboost.XGBoosterSlice(handle::BoosterHandle, begin_layer::Cint, end_layer::Cint, step::Cint, out::Ptr{BoosterHandle})::Cint
+    @ccall libxgboost.XGBoosterSlice(handle::BoosterHandle, begin_layer::Cint, end_layer::Cint, step::Cint, out::Ptr{BoosterHandle})::Cint
 end
 
 function XGBoosterBoostedRounds(handle, out)
-    @ccall lib_xgboost.XGBoosterBoostedRounds(handle::BoosterHandle, out::Ptr{Cint})::Cint
+    @ccall libxgboost.XGBoosterBoostedRounds(handle::BoosterHandle, out::Ptr{Cint})::Cint
 end
 
 function XGBoosterSetParam(handle, name, value)
-    @ccall lib_xgboost.XGBoosterSetParam(handle::BoosterHandle, name::Ptr{Cchar}, value::Ptr{Cchar})::Cint
+    @ccall libxgboost.XGBoosterSetParam(handle::BoosterHandle, name::Ptr{Cchar}, value::Ptr{Cchar})::Cint
 end
 
 function XGBoosterGetNumFeature(handle, out)
-    @ccall lib_xgboost.XGBoosterGetNumFeature(handle::BoosterHandle, out::Ptr{bst_ulong})::Cint
+    @ccall libxgboost.XGBoosterGetNumFeature(handle::BoosterHandle, out::Ptr{bst_ulong})::Cint
 end
 
 function XGBoosterUpdateOneIter(handle, iter, dtrain)
-    @ccall lib_xgboost.XGBoosterUpdateOneIter(handle::BoosterHandle, iter::Cint, dtrain::DMatrixHandle)::Cint
+    @ccall libxgboost.XGBoosterUpdateOneIter(handle::BoosterHandle, iter::Cint, dtrain::DMatrixHandle)::Cint
 end
 
 function XGBoosterBoostOneIter(handle, dtrain, grad, hess, len)
-    @ccall lib_xgboost.XGBoosterBoostOneIter(handle::BoosterHandle, dtrain::DMatrixHandle, grad::Ptr{Cfloat}, hess::Ptr{Cfloat}, len::bst_ulong)::Cint
+    @ccall libxgboost.XGBoosterBoostOneIter(handle::BoosterHandle, dtrain::DMatrixHandle, grad::Ptr{Cfloat}, hess::Ptr{Cfloat}, len::bst_ulong)::Cint
 end
 
 function XGBoosterEvalOneIter(handle, iter, dmats, evnames, len, out_result)
-    @ccall lib_xgboost.XGBoosterEvalOneIter(handle::BoosterHandle, iter::Cint, dmats::Ptr{DMatrixHandle}, evnames::Ptr{Ptr{Cchar}}, len::bst_ulong, out_result::Ptr{Ptr{Cchar}})::Cint
+    @ccall libxgboost.XGBoosterEvalOneIter(handle::BoosterHandle, iter::Cint, dmats::Ptr{DMatrixHandle}, evnames::Ptr{Ptr{Cchar}}, len::bst_ulong, out_result::Ptr{Ptr{Cchar}})::Cint
 end
 
 function XGBoosterPredict(handle, dmat, option_mask, ntree_limit, training, out_len, out_result)
-    @ccall lib_xgboost.XGBoosterPredict(handle::BoosterHandle, dmat::DMatrixHandle, option_mask::Cint, ntree_limit::Cuint, training::Cint, out_len::Ptr{bst_ulong}, out_result::Ptr{Ptr{Cfloat}})::Cint
+    @ccall libxgboost.XGBoosterPredict(handle::BoosterHandle, dmat::DMatrixHandle, option_mask::Cint, ntree_limit::Cuint, training::Cint, out_len::Ptr{bst_ulong}, out_result::Ptr{Ptr{Cfloat}})::Cint
 end
 
 function XGBoosterPredictFromDMatrix(handle, dmat, config, out_shape, out_dim, out_result)
-    @ccall lib_xgboost.XGBoosterPredictFromDMatrix(handle::BoosterHandle, dmat::DMatrixHandle, config::Ptr{Cchar}, out_shape::Ptr{Ptr{bst_ulong}}, out_dim::Ptr{bst_ulong}, out_result::Ptr{Ptr{Cfloat}})::Cint
+    @ccall libxgboost.XGBoosterPredictFromDMatrix(handle::BoosterHandle, dmat::DMatrixHandle, config::Ptr{Cchar}, out_shape::Ptr{Ptr{bst_ulong}}, out_dim::Ptr{bst_ulong}, out_result::Ptr{Ptr{Cfloat}})::Cint
 end
 
 function XGBoosterPredictFromDense(handle, values, config, m, out_shape, out_dim, out_result)
-    @ccall lib_xgboost.XGBoosterPredictFromDense(handle::BoosterHandle, values::Ptr{Cchar}, config::Ptr{Cchar}, m::DMatrixHandle, out_shape::Ptr{Ptr{bst_ulong}}, out_dim::Ptr{bst_ulong}, out_result::Ptr{Ptr{Cfloat}})::Cint
+    @ccall libxgboost.XGBoosterPredictFromDense(handle::BoosterHandle, values::Ptr{Cchar}, config::Ptr{Cchar}, m::DMatrixHandle, out_shape::Ptr{Ptr{bst_ulong}}, out_dim::Ptr{bst_ulong}, out_result::Ptr{Ptr{Cfloat}})::Cint
 end
 
 function XGBoosterPredictFromCSR(handle, indptr, indices, values, ncol, config, m, out_shape, out_dim, out_result)
-    @ccall lib_xgboost.XGBoosterPredictFromCSR(handle::BoosterHandle, indptr::Ptr{Cchar}, indices::Ptr{Cchar}, values::Ptr{Cchar}, ncol::bst_ulong, config::Ptr{Cchar}, m::DMatrixHandle, out_shape::Ptr{Ptr{bst_ulong}}, out_dim::Ptr{bst_ulong}, out_result::Ptr{Ptr{Cfloat}})::Cint
+    @ccall libxgboost.XGBoosterPredictFromCSR(handle::BoosterHandle, indptr::Ptr{Cchar}, indices::Ptr{Cchar}, values::Ptr{Cchar}, ncol::bst_ulong, config::Ptr{Cchar}, m::DMatrixHandle, out_shape::Ptr{Ptr{bst_ulong}}, out_dim::Ptr{bst_ulong}, out_result::Ptr{Ptr{Cfloat}})::Cint
 end
 
 function XGBoosterPredictFromCudaArray(handle, values, config, m, out_shape, out_dim, out_result)
-    @ccall lib_xgboost.XGBoosterPredictFromCudaArray(handle::BoosterHandle, values::Ptr{Cchar}, config::Ptr{Cchar}, m::DMatrixHandle, out_shape::Ptr{Ptr{bst_ulong}}, out_dim::Ptr{bst_ulong}, out_result::Ptr{Ptr{Cfloat}})::Cint
+    @ccall libxgboost.XGBoosterPredictFromCudaArray(handle::BoosterHandle, values::Ptr{Cchar}, config::Ptr{Cchar}, m::DMatrixHandle, out_shape::Ptr{Ptr{bst_ulong}}, out_dim::Ptr{bst_ulong}, out_result::Ptr{Ptr{Cfloat}})::Cint
 end
 
 function XGBoosterPredictFromCudaColumnar(handle, values, config, m, out_shape, out_dim, out_result)
-    @ccall lib_xgboost.XGBoosterPredictFromCudaColumnar(handle::BoosterHandle, values::Ptr{Cchar}, config::Ptr{Cchar}, m::DMatrixHandle, out_shape::Ptr{Ptr{bst_ulong}}, out_dim::Ptr{bst_ulong}, out_result::Ptr{Ptr{Cfloat}})::Cint
+    @ccall libxgboost.XGBoosterPredictFromCudaColumnar(handle::BoosterHandle, values::Ptr{Cchar}, config::Ptr{Cchar}, m::DMatrixHandle, out_shape::Ptr{Ptr{bst_ulong}}, out_dim::Ptr{bst_ulong}, out_result::Ptr{Ptr{Cfloat}})::Cint
 end
 
 function XGBoosterLoadModel(handle, fname)
-    @ccall lib_xgboost.XGBoosterLoadModel(handle::BoosterHandle, fname::Ptr{Cchar})::Cint
+    @ccall libxgboost.XGBoosterLoadModel(handle::BoosterHandle, fname::Ptr{Cchar})::Cint
 end
 
 function XGBoosterSaveModel(handle, fname)
-    @ccall lib_xgboost.XGBoosterSaveModel(handle::BoosterHandle, fname::Ptr{Cchar})::Cint
+    @ccall libxgboost.XGBoosterSaveModel(handle::BoosterHandle, fname::Ptr{Cchar})::Cint
 end
 
 function XGBoosterLoadModelFromBuffer(handle, buf, len)
-    @ccall lib_xgboost.XGBoosterLoadModelFromBuffer(handle::BoosterHandle, buf::Ptr{Cvoid}, len::bst_ulong)::Cint
+    @ccall libxgboost.XGBoosterLoadModelFromBuffer(handle::BoosterHandle, buf::Ptr{Cvoid}, len::bst_ulong)::Cint
 end
 
 function XGBoosterSaveModelToBuffer(handle, config, out_len, out_dptr)
-    @ccall lib_xgboost.XGBoosterSaveModelToBuffer(handle::BoosterHandle, config::Ptr{Cchar}, out_len::Ptr{bst_ulong}, out_dptr::Ptr{Ptr{Cchar}})::Cint
+    @ccall libxgboost.XGBoosterSaveModelToBuffer(handle::BoosterHandle, config::Ptr{Cchar}, out_len::Ptr{bst_ulong}, out_dptr::Ptr{Ptr{Cchar}})::Cint
 end
 
 function XGBoosterGetModelRaw(handle, out_len, out_dptr)
-    @ccall lib_xgboost.XGBoosterGetModelRaw(handle::BoosterHandle, out_len::Ptr{bst_ulong}, out_dptr::Ptr{Ptr{Cchar}})::Cint
+    @ccall libxgboost.XGBoosterGetModelRaw(handle::BoosterHandle, out_len::Ptr{bst_ulong}, out_dptr::Ptr{Ptr{Cchar}})::Cint
 end
 
 function XGBoosterSerializeToBuffer(handle, out_len, out_dptr)
-    @ccall lib_xgboost.XGBoosterSerializeToBuffer(handle::BoosterHandle, out_len::Ptr{bst_ulong}, out_dptr::Ptr{Ptr{Cchar}})::Cint
+    @ccall libxgboost.XGBoosterSerializeToBuffer(handle::BoosterHandle, out_len::Ptr{bst_ulong}, out_dptr::Ptr{Ptr{Cchar}})::Cint
 end
 
 function XGBoosterUnserializeFromBuffer(handle, buf, len)
-    @ccall lib_xgboost.XGBoosterUnserializeFromBuffer(handle::BoosterHandle, buf::Ptr{Cvoid}, len::bst_ulong)::Cint
+    @ccall libxgboost.XGBoosterUnserializeFromBuffer(handle::BoosterHandle, buf::Ptr{Cvoid}, len::bst_ulong)::Cint
 end
 
 function XGBoosterLoadRabitCheckpoint(handle, version)
-    @ccall lib_xgboost.XGBoosterLoadRabitCheckpoint(handle::BoosterHandle, version::Ptr{Cint})::Cint
+    @ccall libxgboost.XGBoosterLoadRabitCheckpoint(handle::BoosterHandle, version::Ptr{Cint})::Cint
 end
 
 function XGBoosterSaveRabitCheckpoint(handle)
-    @ccall lib_xgboost.XGBoosterSaveRabitCheckpoint(handle::BoosterHandle)::Cint
+    @ccall libxgboost.XGBoosterSaveRabitCheckpoint(handle::BoosterHandle)::Cint
 end
 
 function XGBoosterSaveJsonConfig(handle, out_len, out_str)
-    @ccall lib_xgboost.XGBoosterSaveJsonConfig(handle::BoosterHandle, out_len::Ptr{bst_ulong}, out_str::Ptr{Ptr{Cchar}})::Cint
+    @ccall libxgboost.XGBoosterSaveJsonConfig(handle::BoosterHandle, out_len::Ptr{bst_ulong}, out_str::Ptr{Ptr{Cchar}})::Cint
 end
 
 function XGBoosterLoadJsonConfig(handle, config)
-    @ccall lib_xgboost.XGBoosterLoadJsonConfig(handle::BoosterHandle, config::Ptr{Cchar})::Cint
+    @ccall libxgboost.XGBoosterLoadJsonConfig(handle::BoosterHandle, config::Ptr{Cchar})::Cint
 end
 
 function XGBoosterDumpModel(handle, fmap, with_stats, out_len, out_dump_array)
-    @ccall lib_xgboost.XGBoosterDumpModel(handle::BoosterHandle, fmap::Ptr{Cchar}, with_stats::Cint, out_len::Ptr{bst_ulong}, out_dump_array::Ptr{Ptr{Ptr{Cchar}}})::Cint
+    @ccall libxgboost.XGBoosterDumpModel(handle::BoosterHandle, fmap::Ptr{Cchar}, with_stats::Cint, out_len::Ptr{bst_ulong}, out_dump_array::Ptr{Ptr{Ptr{Cchar}}})::Cint
 end
 
 function XGBoosterDumpModelEx(handle, fmap, with_stats, format, out_len, out_dump_array)
-    @ccall lib_xgboost.XGBoosterDumpModelEx(handle::BoosterHandle, fmap::Ptr{Cchar}, with_stats::Cint, format::Ptr{Cchar}, out_len::Ptr{bst_ulong}, out_dump_array::Ptr{Ptr{Ptr{Cchar}}})::Cint
+    @ccall libxgboost.XGBoosterDumpModelEx(handle::BoosterHandle, fmap::Ptr{Cchar}, with_stats::Cint, format::Ptr{Cchar}, out_len::Ptr{bst_ulong}, out_dump_array::Ptr{Ptr{Ptr{Cchar}}})::Cint
 end
 
 function XGBoosterDumpModelWithFeatures(handle, fnum, fname, ftype, with_stats, out_len, out_models)
-    @ccall lib_xgboost.XGBoosterDumpModelWithFeatures(handle::BoosterHandle, fnum::Cint, fname::Ptr{Ptr{Cchar}}, ftype::Ptr{Ptr{Cchar}}, with_stats::Cint, out_len::Ptr{bst_ulong}, out_models::Ptr{Ptr{Ptr{Cchar}}})::Cint
+    @ccall libxgboost.XGBoosterDumpModelWithFeatures(handle::BoosterHandle, fnum::Cint, fname::Ptr{Ptr{Cchar}}, ftype::Ptr{Ptr{Cchar}}, with_stats::Cint, out_len::Ptr{bst_ulong}, out_models::Ptr{Ptr{Ptr{Cchar}}})::Cint
 end
 
 function XGBoosterDumpModelExWithFeatures(handle, fnum, fname, ftype, with_stats, format, out_len, out_models)
-    @ccall lib_xgboost.XGBoosterDumpModelExWithFeatures(handle::BoosterHandle, fnum::Cint, fname::Ptr{Ptr{Cchar}}, ftype::Ptr{Ptr{Cchar}}, with_stats::Cint, format::Ptr{Cchar}, out_len::Ptr{bst_ulong}, out_models::Ptr{Ptr{Ptr{Cchar}}})::Cint
+    @ccall libxgboost.XGBoosterDumpModelExWithFeatures(handle::BoosterHandle, fnum::Cint, fname::Ptr{Ptr{Cchar}}, ftype::Ptr{Ptr{Cchar}}, with_stats::Cint, format::Ptr{Cchar}, out_len::Ptr{bst_ulong}, out_models::Ptr{Ptr{Ptr{Cchar}}})::Cint
 end
 
 function XGBoosterGetAttr(handle, key, out, success)
-    @ccall lib_xgboost.XGBoosterGetAttr(handle::BoosterHandle, key::Ptr{Cchar}, out::Ptr{Ptr{Cchar}}, success::Ptr{Cint})::Cint
+    @ccall libxgboost.XGBoosterGetAttr(handle::BoosterHandle, key::Ptr{Cchar}, out::Ptr{Ptr{Cchar}}, success::Ptr{Cint})::Cint
 end
 
 function XGBoosterSetAttr(handle, key, value)
-    @ccall lib_xgboost.XGBoosterSetAttr(handle::BoosterHandle, key::Ptr{Cchar}, value::Ptr{Cchar})::Cint
+    @ccall libxgboost.XGBoosterSetAttr(handle::BoosterHandle, key::Ptr{Cchar}, value::Ptr{Cchar})::Cint
 end
 
 function XGBoosterGetAttrNames(handle, out_len, out)
-    @ccall lib_xgboost.XGBoosterGetAttrNames(handle::BoosterHandle, out_len::Ptr{bst_ulong}, out::Ptr{Ptr{Ptr{Cchar}}})::Cint
+    @ccall libxgboost.XGBoosterGetAttrNames(handle::BoosterHandle, out_len::Ptr{bst_ulong}, out::Ptr{Ptr{Ptr{Cchar}}})::Cint
 end
 
 function XGBoosterSetStrFeatureInfo(handle, field, features, size)
-    @ccall lib_xgboost.XGBoosterSetStrFeatureInfo(handle::BoosterHandle, field::Ptr{Cchar}, features::Ptr{Ptr{Cchar}}, size::bst_ulong)::Cint
+    @ccall libxgboost.XGBoosterSetStrFeatureInfo(handle::BoosterHandle, field::Ptr{Cchar}, features::Ptr{Ptr{Cchar}}, size::bst_ulong)::Cint
 end
 
 function XGBoosterGetStrFeatureInfo(handle, field, len, out_features)
-    @ccall lib_xgboost.XGBoosterGetStrFeatureInfo(handle::BoosterHandle, field::Ptr{Cchar}, len::Ptr{bst_ulong}, out_features::Ptr{Ptr{Ptr{Cchar}}})::Cint
+    @ccall libxgboost.XGBoosterGetStrFeatureInfo(handle::BoosterHandle, field::Ptr{Cchar}, len::Ptr{bst_ulong}, out_features::Ptr{Ptr{Ptr{Cchar}}})::Cint
 end
 
 function XGBoosterFeatureScore(handle, config, out_n_features, out_features, out_dim, out_shape, out_scores)
-    @ccall lib_xgboost.XGBoosterFeatureScore(handle::BoosterHandle, config::Ptr{Cchar}, out_n_features::Ptr{bst_ulong}, out_features::Ptr{Ptr{Ptr{Cchar}}}, out_dim::Ptr{bst_ulong}, out_shape::Ptr{Ptr{bst_ulong}}, out_scores::Ptr{Ptr{Cfloat}})::Cint
+    @ccall libxgboost.XGBoosterFeatureScore(handle::BoosterHandle, config::Ptr{Cchar}, out_n_features::Ptr{bst_ulong}, out_features::Ptr{Ptr{Ptr{Cchar}}}, out_dim::Ptr{bst_ulong}, out_shape::Ptr{Ptr{bst_ulong}}, out_scores::Ptr{Ptr{Cfloat}})::Cint
 end
 
 function XGCommunicatorInit(config)
-    @ccall lib_xgboost.XGCommunicatorInit(config::Ptr{Cchar})::Cint
+    @ccall libxgboost.XGCommunicatorInit(config::Ptr{Cchar})::Cint
 end
 
 function XGCommunicatorFinalize()
-    @ccall lib_xgboost.XGCommunicatorFinalize()::Cint
+    @ccall libxgboost.XGCommunicatorFinalize()::Cint
 end
 
 function XGCommunicatorGetRank()
-    @ccall lib_xgboost.XGCommunicatorGetRank()::Cint
+    @ccall libxgboost.XGCommunicatorGetRank()::Cint
 end
 
 function XGCommunicatorGetWorldSize()
-    @ccall lib_xgboost.XGCommunicatorGetWorldSize()::Cint
+    @ccall libxgboost.XGCommunicatorGetWorldSize()::Cint
 end
 
 function XGCommunicatorIsDistributed()
-    @ccall lib_xgboost.XGCommunicatorIsDistributed()::Cint
+    @ccall libxgboost.XGCommunicatorIsDistributed()::Cint
 end
 
 function XGCommunicatorPrint(message)
-    @ccall lib_xgboost.XGCommunicatorPrint(message::Ptr{Cchar})::Cint
+    @ccall libxgboost.XGCommunicatorPrint(message::Ptr{Cchar})::Cint
 end
 
 function XGCommunicatorGetProcessorName(name_str)
-    @ccall lib_xgboost.XGCommunicatorGetProcessorName(name_str::Ptr{Ptr{Cchar}})::Cint
+    @ccall libxgboost.XGCommunicatorGetProcessorName(name_str::Ptr{Ptr{Cchar}})::Cint
 end
 
 function XGCommunicatorBroadcast(send_receive_buffer, size, root)
-    @ccall lib_xgboost.XGCommunicatorBroadcast(send_receive_buffer::Ptr{Cvoid}, size::Csize_t, root::Cint)::Cint
+    @ccall libxgboost.XGCommunicatorBroadcast(send_receive_buffer::Ptr{Cvoid}, size::Csize_t, root::Cint)::Cint
 end
 
 function XGCommunicatorAllreduce(send_receive_buffer, count, data_type, op)
-    @ccall lib_xgboost.XGCommunicatorAllreduce(send_receive_buffer::Ptr{Cvoid}, count::Csize_t, data_type::Cint, op::Cint)::Cint
+    @ccall libxgboost.XGCommunicatorAllreduce(send_receive_buffer::Ptr{Cvoid}, count::Csize_t, data_type::Cint, op::Cint)::Cint
 end
 
 # Skipping MacroDefinition: XGB_DLL XGB_EXTERN_C __attribute__ ( ( visibility ( "default" ) ) )

--- a/src/Lib.jl
+++ b/src/Lib.jl
@@ -1,10 +1,17 @@
 module Lib
 
 using XGBoost_jll
-export XGBoost_jll
+using XGBoost_GPU_jll
 
 using CEnum
 
+# only enable GPU support if there is a valid binary compatible with this system
+# should we place a warning here?
+if XGBoost_GPU_jll.is_available()
+    lib_xgboost = XGBoost_GPU_jll.libxgboost
+else
+    lib_xgboost = XGBoost_jll.libxgboost
+end
 
 struct XGBoostError <: Exception
     caller
@@ -40,76 +47,76 @@ const DMatrixHandle = Ptr{Cvoid}
 const BoosterHandle = Ptr{Cvoid}
 
 function XGBoostVersion(major, minor, patch)
-    @ccall libxgboost.XGBoostVersion(major::Ptr{Cint}, minor::Ptr{Cint}, patch::Ptr{Cint})::Cvoid
+    @ccall lib_xgboost.XGBoostVersion(major::Ptr{Cint}, minor::Ptr{Cint}, patch::Ptr{Cint})::Cvoid
 end
 
 function XGBuildInfo(out)
-    @ccall libxgboost.XGBuildInfo(out::Ptr{Ptr{Cchar}})::Cint
+    @ccall lib_xgboost.XGBuildInfo(out::Ptr{Ptr{Cchar}})::Cint
 end
 
 # no prototype is found for this function at c_api.h:84:21, please use with caution
 function XGBGetLastError()
-    @ccall libxgboost.XGBGetLastError()::Ptr{Cchar}
+    @ccall lib_xgboost.XGBGetLastError()::Ptr{Cchar}
 end
 
 function XGBRegisterLogCallback(callback)
-    @ccall libxgboost.XGBRegisterLogCallback(callback::Ptr{Cvoid})::Cint
+    @ccall lib_xgboost.XGBRegisterLogCallback(callback::Ptr{Cvoid})::Cint
 end
 
 function XGBSetGlobalConfig(config)
-    @ccall libxgboost.XGBSetGlobalConfig(config::Ptr{Cchar})::Cint
+    @ccall lib_xgboost.XGBSetGlobalConfig(config::Ptr{Cchar})::Cint
 end
 
 function XGBGetGlobalConfig(out_config)
-    @ccall libxgboost.XGBGetGlobalConfig(out_config::Ptr{Ptr{Cchar}})::Cint
+    @ccall lib_xgboost.XGBGetGlobalConfig(out_config::Ptr{Ptr{Cchar}})::Cint
 end
 
 function XGDMatrixCreateFromFile(fname, silent, out)
-    @ccall libxgboost.XGDMatrixCreateFromFile(fname::Ptr{Cchar}, silent::Cint, out::Ptr{DMatrixHandle})::Cint
+    @ccall lib_xgboost.XGDMatrixCreateFromFile(fname::Ptr{Cchar}, silent::Cint, out::Ptr{DMatrixHandle})::Cint
 end
 
 function XGDMatrixCreateFromURI(config, out)
-    @ccall libxgboost.XGDMatrixCreateFromURI(config::Ptr{Cchar}, out::Ptr{DMatrixHandle})::Cint
+    @ccall lib_xgboost.XGDMatrixCreateFromURI(config::Ptr{Cchar}, out::Ptr{DMatrixHandle})::Cint
 end
 
 function XGDMatrixCreateFromCSREx(indptr, indices, data, nindptr, nelem, num_col, out)
-    @ccall libxgboost.XGDMatrixCreateFromCSREx(indptr::Ptr{Csize_t}, indices::Ptr{Cuint}, data::Ptr{Cfloat}, nindptr::Csize_t, nelem::Csize_t, num_col::Csize_t, out::Ptr{DMatrixHandle})::Cint
+    @ccall lib_xgboost.XGDMatrixCreateFromCSREx(indptr::Ptr{Csize_t}, indices::Ptr{Cuint}, data::Ptr{Cfloat}, nindptr::Csize_t, nelem::Csize_t, num_col::Csize_t, out::Ptr{DMatrixHandle})::Cint
 end
 
 function XGDMatrixCreateFromCSR(indptr, indices, data, ncol, config, out)
-    @ccall libxgboost.XGDMatrixCreateFromCSR(indptr::Ptr{Cchar}, indices::Ptr{Cchar}, data::Ptr{Cchar}, ncol::bst_ulong, config::Ptr{Cchar}, out::Ptr{DMatrixHandle})::Cint
+    @ccall lib_xgboost.XGDMatrixCreateFromCSR(indptr::Ptr{Cchar}, indices::Ptr{Cchar}, data::Ptr{Cchar}, ncol::bst_ulong, config::Ptr{Cchar}, out::Ptr{DMatrixHandle})::Cint
 end
 
 function XGDMatrixCreateFromDense(data, config, out)
-    @ccall libxgboost.XGDMatrixCreateFromDense(data::Ptr{Cchar}, config::Ptr{Cchar}, out::Ptr{DMatrixHandle})::Cint
+    @ccall lib_xgboost.XGDMatrixCreateFromDense(data::Ptr{Cchar}, config::Ptr{Cchar}, out::Ptr{DMatrixHandle})::Cint
 end
 
 function XGDMatrixCreateFromCSC(indptr, indices, data, nrow, config, out)
-    @ccall libxgboost.XGDMatrixCreateFromCSC(indptr::Ptr{Cchar}, indices::Ptr{Cchar}, data::Ptr{Cchar}, nrow::bst_ulong, config::Ptr{Cchar}, out::Ptr{DMatrixHandle})::Cint
+    @ccall lib_xgboost.XGDMatrixCreateFromCSC(indptr::Ptr{Cchar}, indices::Ptr{Cchar}, data::Ptr{Cchar}, nrow::bst_ulong, config::Ptr{Cchar}, out::Ptr{DMatrixHandle})::Cint
 end
 
 function XGDMatrixCreateFromCSCEx(col_ptr, indices, data, nindptr, nelem, num_row, out)
-    @ccall libxgboost.XGDMatrixCreateFromCSCEx(col_ptr::Ptr{Csize_t}, indices::Ptr{Cuint}, data::Ptr{Cfloat}, nindptr::Csize_t, nelem::Csize_t, num_row::Csize_t, out::Ptr{DMatrixHandle})::Cint
+    @ccall lib_xgboost.XGDMatrixCreateFromCSCEx(col_ptr::Ptr{Csize_t}, indices::Ptr{Cuint}, data::Ptr{Cfloat}, nindptr::Csize_t, nelem::Csize_t, num_row::Csize_t, out::Ptr{DMatrixHandle})::Cint
 end
 
 function XGDMatrixCreateFromMat(data, nrow, ncol, missing, out)
-    @ccall libxgboost.XGDMatrixCreateFromMat(data::Ptr{Cfloat}, nrow::bst_ulong, ncol::bst_ulong, missing::Cfloat, out::Ptr{DMatrixHandle})::Cint
+    @ccall lib_xgboost.XGDMatrixCreateFromMat(data::Ptr{Cfloat}, nrow::bst_ulong, ncol::bst_ulong, missing::Cfloat, out::Ptr{DMatrixHandle})::Cint
 end
 
 function XGDMatrixCreateFromMat_omp(data, nrow, ncol, missing, out, nthread)
-    @ccall libxgboost.XGDMatrixCreateFromMat_omp(data::Ptr{Cfloat}, nrow::bst_ulong, ncol::bst_ulong, missing::Cfloat, out::Ptr{DMatrixHandle}, nthread::Cint)::Cint
+    @ccall lib_xgboost.XGDMatrixCreateFromMat_omp(data::Ptr{Cfloat}, nrow::bst_ulong, ncol::bst_ulong, missing::Cfloat, out::Ptr{DMatrixHandle}, nthread::Cint)::Cint
 end
 
 function XGDMatrixCreateFromDT(data, feature_stypes, nrow, ncol, out, nthread)
-    @ccall libxgboost.XGDMatrixCreateFromDT(data::Ptr{Ptr{Cvoid}}, feature_stypes::Ptr{Ptr{Cchar}}, nrow::bst_ulong, ncol::bst_ulong, out::Ptr{DMatrixHandle}, nthread::Cint)::Cint
+    @ccall lib_xgboost.XGDMatrixCreateFromDT(data::Ptr{Ptr{Cvoid}}, feature_stypes::Ptr{Ptr{Cchar}}, nrow::bst_ulong, ncol::bst_ulong, out::Ptr{DMatrixHandle}, nthread::Cint)::Cint
 end
 
 function XGDMatrixCreateFromCudaColumnar(data, config, out)
-    @ccall libxgboost.XGDMatrixCreateFromCudaColumnar(data::Ptr{Cchar}, config::Ptr{Cchar}, out::Ptr{DMatrixHandle})::Cint
+    @ccall lib_xgboost.XGDMatrixCreateFromCudaColumnar(data::Ptr{Cchar}, config::Ptr{Cchar}, out::Ptr{DMatrixHandle})::Cint
 end
 
 function XGDMatrixCreateFromCudaArrayInterface(data, config, out)
-    @ccall libxgboost.XGDMatrixCreateFromCudaArrayInterface(data::Ptr{Cchar}, config::Ptr{Cchar}, out::Ptr{DMatrixHandle})::Cint
+    @ccall lib_xgboost.XGDMatrixCreateFromCudaArrayInterface(data::Ptr{Cchar}, config::Ptr{Cchar}, out::Ptr{DMatrixHandle})::Cint
 end
 
 const DataIterHandle = Ptr{Cvoid}
@@ -133,11 +140,11 @@ const XGBCallbackSetData = Cvoid
 const XGBCallbackDataIterNext = Cvoid
 
 function XGDMatrixCreateFromDataIter(data_handle, callback, cache_info, out)
-    @ccall libxgboost.XGDMatrixCreateFromDataIter(data_handle::DataIterHandle, callback::Ptr{XGBCallbackDataIterNext}, cache_info::Ptr{Cchar}, out::Ptr{DMatrixHandle})::Cint
+    @ccall lib_xgboost.XGDMatrixCreateFromDataIter(data_handle::DataIterHandle, callback::Ptr{XGBCallbackDataIterNext}, cache_info::Ptr{Cchar}, out::Ptr{DMatrixHandle})::Cint
 end
 
 function XGProxyDMatrixCreate(out)
-    @ccall libxgboost.XGProxyDMatrixCreate(out::Ptr{DMatrixHandle})::Cint
+    @ccall lib_xgboost.XGProxyDMatrixCreate(out::Ptr{DMatrixHandle})::Cint
 end
 
 # typedef int XGDMatrixCallbackNext ( DataIterHandle iter )
@@ -147,291 +154,291 @@ const XGDMatrixCallbackNext = Cvoid
 const DataIterResetCallback = Cvoid
 
 function XGDMatrixCreateFromCallback(iter, proxy, reset, next, config, out)
-    @ccall libxgboost.XGDMatrixCreateFromCallback(iter::DataIterHandle, proxy::DMatrixHandle, reset::Ptr{DataIterResetCallback}, next::Ptr{XGDMatrixCallbackNext}, config::Ptr{Cchar}, out::Ptr{DMatrixHandle})::Cint
+    @ccall lib_xgboost.XGDMatrixCreateFromCallback(iter::DataIterHandle, proxy::DMatrixHandle, reset::Ptr{DataIterResetCallback}, next::Ptr{XGDMatrixCallbackNext}, config::Ptr{Cchar}, out::Ptr{DMatrixHandle})::Cint
 end
 
 function XGQuantileDMatrixCreateFromCallback(iter, proxy, ref, reset, next, config, out)
-    @ccall libxgboost.XGQuantileDMatrixCreateFromCallback(iter::DataIterHandle, proxy::DMatrixHandle, ref::DataIterHandle, reset::Ptr{DataIterResetCallback}, next::Ptr{XGDMatrixCallbackNext}, config::Ptr{Cchar}, out::Ptr{DMatrixHandle})::Cint
+    @ccall lib_xgboost.XGQuantileDMatrixCreateFromCallback(iter::DataIterHandle, proxy::DMatrixHandle, ref::DataIterHandle, reset::Ptr{DataIterResetCallback}, next::Ptr{XGDMatrixCallbackNext}, config::Ptr{Cchar}, out::Ptr{DMatrixHandle})::Cint
 end
 
 function XGDeviceQuantileDMatrixCreateFromCallback(iter, proxy, reset, next, missing, nthread, max_bin, out)
-    @ccall libxgboost.XGDeviceQuantileDMatrixCreateFromCallback(iter::DataIterHandle, proxy::DMatrixHandle, reset::Ptr{DataIterResetCallback}, next::Ptr{XGDMatrixCallbackNext}, missing::Cfloat, nthread::Cint, max_bin::Cint, out::Ptr{DMatrixHandle})::Cint
+    @ccall lib_xgboost.XGDeviceQuantileDMatrixCreateFromCallback(iter::DataIterHandle, proxy::DMatrixHandle, reset::Ptr{DataIterResetCallback}, next::Ptr{XGDMatrixCallbackNext}, missing::Cfloat, nthread::Cint, max_bin::Cint, out::Ptr{DMatrixHandle})::Cint
 end
 
 function XGProxyDMatrixSetDataCudaArrayInterface(handle, c_interface_str)
-    @ccall libxgboost.XGProxyDMatrixSetDataCudaArrayInterface(handle::DMatrixHandle, c_interface_str::Ptr{Cchar})::Cint
+    @ccall lib_xgboost.XGProxyDMatrixSetDataCudaArrayInterface(handle::DMatrixHandle, c_interface_str::Ptr{Cchar})::Cint
 end
 
 function XGProxyDMatrixSetDataCudaColumnar(handle, c_interface_str)
-    @ccall libxgboost.XGProxyDMatrixSetDataCudaColumnar(handle::DMatrixHandle, c_interface_str::Ptr{Cchar})::Cint
+    @ccall lib_xgboost.XGProxyDMatrixSetDataCudaColumnar(handle::DMatrixHandle, c_interface_str::Ptr{Cchar})::Cint
 end
 
 function XGProxyDMatrixSetDataDense(handle, c_interface_str)
-    @ccall libxgboost.XGProxyDMatrixSetDataDense(handle::DMatrixHandle, c_interface_str::Ptr{Cchar})::Cint
+    @ccall lib_xgboost.XGProxyDMatrixSetDataDense(handle::DMatrixHandle, c_interface_str::Ptr{Cchar})::Cint
 end
 
 function XGProxyDMatrixSetDataCSR(handle, indptr, indices, data, ncol)
-    @ccall libxgboost.XGProxyDMatrixSetDataCSR(handle::DMatrixHandle, indptr::Ptr{Cchar}, indices::Ptr{Cchar}, data::Ptr{Cchar}, ncol::bst_ulong)::Cint
+    @ccall lib_xgboost.XGProxyDMatrixSetDataCSR(handle::DMatrixHandle, indptr::Ptr{Cchar}, indices::Ptr{Cchar}, data::Ptr{Cchar}, ncol::bst_ulong)::Cint
 end
 
 function XGImportArrowRecordBatch(data_handle, ptr_array, ptr_schema)
-    @ccall libxgboost.XGImportArrowRecordBatch(data_handle::DataIterHandle, ptr_array::Ptr{Cvoid}, ptr_schema::Ptr{Cvoid})::Cint
+    @ccall lib_xgboost.XGImportArrowRecordBatch(data_handle::DataIterHandle, ptr_array::Ptr{Cvoid}, ptr_schema::Ptr{Cvoid})::Cint
 end
 
 function XGDMatrixCreateFromArrowCallback(next, config, out)
-    @ccall libxgboost.XGDMatrixCreateFromArrowCallback(next::Ptr{XGDMatrixCallbackNext}, config::Ptr{Cchar}, out::Ptr{DMatrixHandle})::Cint
+    @ccall lib_xgboost.XGDMatrixCreateFromArrowCallback(next::Ptr{XGDMatrixCallbackNext}, config::Ptr{Cchar}, out::Ptr{DMatrixHandle})::Cint
 end
 
 function XGDMatrixSliceDMatrix(handle, idxset, len, out)
-    @ccall libxgboost.XGDMatrixSliceDMatrix(handle::DMatrixHandle, idxset::Ptr{Cint}, len::bst_ulong, out::Ptr{DMatrixHandle})::Cint
+    @ccall lib_xgboost.XGDMatrixSliceDMatrix(handle::DMatrixHandle, idxset::Ptr{Cint}, len::bst_ulong, out::Ptr{DMatrixHandle})::Cint
 end
 
 function XGDMatrixSliceDMatrixEx(handle, idxset, len, out, allow_groups)
-    @ccall libxgboost.XGDMatrixSliceDMatrixEx(handle::DMatrixHandle, idxset::Ptr{Cint}, len::bst_ulong, out::Ptr{DMatrixHandle}, allow_groups::Cint)::Cint
+    @ccall lib_xgboost.XGDMatrixSliceDMatrixEx(handle::DMatrixHandle, idxset::Ptr{Cint}, len::bst_ulong, out::Ptr{DMatrixHandle}, allow_groups::Cint)::Cint
 end
 
 function XGDMatrixFree(handle)
-    @ccall libxgboost.XGDMatrixFree(handle::DMatrixHandle)::Cint
+    @ccall lib_xgboost.XGDMatrixFree(handle::DMatrixHandle)::Cint
 end
 
 function XGDMatrixSaveBinary(handle, fname, silent)
-    @ccall libxgboost.XGDMatrixSaveBinary(handle::DMatrixHandle, fname::Ptr{Cchar}, silent::Cint)::Cint
+    @ccall lib_xgboost.XGDMatrixSaveBinary(handle::DMatrixHandle, fname::Ptr{Cchar}, silent::Cint)::Cint
 end
 
 function XGDMatrixSetInfoFromInterface(handle, field, c_interface_str)
-    @ccall libxgboost.XGDMatrixSetInfoFromInterface(handle::DMatrixHandle, field::Ptr{Cchar}, c_interface_str::Ptr{Cchar})::Cint
+    @ccall lib_xgboost.XGDMatrixSetInfoFromInterface(handle::DMatrixHandle, field::Ptr{Cchar}, c_interface_str::Ptr{Cchar})::Cint
 end
 
 function XGDMatrixSetFloatInfo(handle, field, array, len)
-    @ccall libxgboost.XGDMatrixSetFloatInfo(handle::DMatrixHandle, field::Ptr{Cchar}, array::Ptr{Cfloat}, len::bst_ulong)::Cint
+    @ccall lib_xgboost.XGDMatrixSetFloatInfo(handle::DMatrixHandle, field::Ptr{Cchar}, array::Ptr{Cfloat}, len::bst_ulong)::Cint
 end
 
 function XGDMatrixSetUIntInfo(handle, field, array, len)
-    @ccall libxgboost.XGDMatrixSetUIntInfo(handle::DMatrixHandle, field::Ptr{Cchar}, array::Ptr{Cuint}, len::bst_ulong)::Cint
+    @ccall lib_xgboost.XGDMatrixSetUIntInfo(handle::DMatrixHandle, field::Ptr{Cchar}, array::Ptr{Cuint}, len::bst_ulong)::Cint
 end
 
 function XGDMatrixSetStrFeatureInfo(handle, field, features, size)
-    @ccall libxgboost.XGDMatrixSetStrFeatureInfo(handle::DMatrixHandle, field::Ptr{Cchar}, features::Ptr{Ptr{Cchar}}, size::bst_ulong)::Cint
+    @ccall lib_xgboost.XGDMatrixSetStrFeatureInfo(handle::DMatrixHandle, field::Ptr{Cchar}, features::Ptr{Ptr{Cchar}}, size::bst_ulong)::Cint
 end
 
 function XGDMatrixGetStrFeatureInfo(handle, field, size, out_features)
-    @ccall libxgboost.XGDMatrixGetStrFeatureInfo(handle::DMatrixHandle, field::Ptr{Cchar}, size::Ptr{bst_ulong}, out_features::Ptr{Ptr{Ptr{Cchar}}})::Cint
+    @ccall lib_xgboost.XGDMatrixGetStrFeatureInfo(handle::DMatrixHandle, field::Ptr{Cchar}, size::Ptr{bst_ulong}, out_features::Ptr{Ptr{Ptr{Cchar}}})::Cint
 end
 
 function XGDMatrixSetDenseInfo(handle, field, data, size, type)
-    @ccall libxgboost.XGDMatrixSetDenseInfo(handle::DMatrixHandle, field::Ptr{Cchar}, data::Ptr{Cvoid}, size::bst_ulong, type::Cint)::Cint
+    @ccall lib_xgboost.XGDMatrixSetDenseInfo(handle::DMatrixHandle, field::Ptr{Cchar}, data::Ptr{Cvoid}, size::bst_ulong, type::Cint)::Cint
 end
 
 function XGDMatrixSetGroup(handle, group, len)
-    @ccall libxgboost.XGDMatrixSetGroup(handle::DMatrixHandle, group::Ptr{Cuint}, len::bst_ulong)::Cint
+    @ccall lib_xgboost.XGDMatrixSetGroup(handle::DMatrixHandle, group::Ptr{Cuint}, len::bst_ulong)::Cint
 end
 
 function XGDMatrixGetFloatInfo(handle, field, out_len, out_dptr)
-    @ccall libxgboost.XGDMatrixGetFloatInfo(handle::DMatrixHandle, field::Ptr{Cchar}, out_len::Ptr{bst_ulong}, out_dptr::Ptr{Ptr{Cfloat}})::Cint
+    @ccall lib_xgboost.XGDMatrixGetFloatInfo(handle::DMatrixHandle, field::Ptr{Cchar}, out_len::Ptr{bst_ulong}, out_dptr::Ptr{Ptr{Cfloat}})::Cint
 end
 
 function XGDMatrixGetUIntInfo(handle, field, out_len, out_dptr)
-    @ccall libxgboost.XGDMatrixGetUIntInfo(handle::DMatrixHandle, field::Ptr{Cchar}, out_len::Ptr{bst_ulong}, out_dptr::Ptr{Ptr{Cuint}})::Cint
+    @ccall lib_xgboost.XGDMatrixGetUIntInfo(handle::DMatrixHandle, field::Ptr{Cchar}, out_len::Ptr{bst_ulong}, out_dptr::Ptr{Ptr{Cuint}})::Cint
 end
 
 function XGDMatrixNumRow(handle, out)
-    @ccall libxgboost.XGDMatrixNumRow(handle::DMatrixHandle, out::Ptr{bst_ulong})::Cint
+    @ccall lib_xgboost.XGDMatrixNumRow(handle::DMatrixHandle, out::Ptr{bst_ulong})::Cint
 end
 
 function XGDMatrixNumCol(handle, out)
-    @ccall libxgboost.XGDMatrixNumCol(handle::DMatrixHandle, out::Ptr{bst_ulong})::Cint
+    @ccall lib_xgboost.XGDMatrixNumCol(handle::DMatrixHandle, out::Ptr{bst_ulong})::Cint
 end
 
 function XGDMatrixNumNonMissing(handle, out)
-    @ccall libxgboost.XGDMatrixNumNonMissing(handle::DMatrixHandle, out::Ptr{bst_ulong})::Cint
+    @ccall lib_xgboost.XGDMatrixNumNonMissing(handle::DMatrixHandle, out::Ptr{bst_ulong})::Cint
 end
 
 function XGDMatrixGetDataAsCSR(handle, config, out_indptr, out_indices, out_data)
-    @ccall libxgboost.XGDMatrixGetDataAsCSR(handle::DMatrixHandle, config::Ptr{Cchar}, out_indptr::Ptr{bst_ulong}, out_indices::Ptr{Cuint}, out_data::Ptr{Cfloat})::Cint
+    @ccall lib_xgboost.XGDMatrixGetDataAsCSR(handle::DMatrixHandle, config::Ptr{Cchar}, out_indptr::Ptr{bst_ulong}, out_indices::Ptr{Cuint}, out_data::Ptr{Cfloat})::Cint
 end
 
 function XGDMatrixGetQuantileCut(handle, config, out_indptr, out_data)
-    @ccall libxgboost.XGDMatrixGetQuantileCut(handle::DMatrixHandle, config::Ptr{Cchar}, out_indptr::Ptr{Ptr{Cchar}}, out_data::Ptr{Ptr{Cchar}})::Cint
+    @ccall lib_xgboost.XGDMatrixGetQuantileCut(handle::DMatrixHandle, config::Ptr{Cchar}, out_indptr::Ptr{Ptr{Cchar}}, out_data::Ptr{Ptr{Cchar}})::Cint
 end
 
 function XGBoosterCreate(dmats, len, out)
-    @ccall libxgboost.XGBoosterCreate(dmats::Ptr{DMatrixHandle}, len::bst_ulong, out::Ptr{BoosterHandle})::Cint
+    @ccall lib_xgboost.XGBoosterCreate(dmats::Ptr{DMatrixHandle}, len::bst_ulong, out::Ptr{BoosterHandle})::Cint
 end
 
 function XGBoosterFree(handle)
-    @ccall libxgboost.XGBoosterFree(handle::BoosterHandle)::Cint
+    @ccall lib_xgboost.XGBoosterFree(handle::BoosterHandle)::Cint
 end
 
 function XGBoosterSlice(handle, begin_layer, end_layer, step, out)
-    @ccall libxgboost.XGBoosterSlice(handle::BoosterHandle, begin_layer::Cint, end_layer::Cint, step::Cint, out::Ptr{BoosterHandle})::Cint
+    @ccall lib_xgboost.XGBoosterSlice(handle::BoosterHandle, begin_layer::Cint, end_layer::Cint, step::Cint, out::Ptr{BoosterHandle})::Cint
 end
 
 function XGBoosterBoostedRounds(handle, out)
-    @ccall libxgboost.XGBoosterBoostedRounds(handle::BoosterHandle, out::Ptr{Cint})::Cint
+    @ccall lib_xgboost.XGBoosterBoostedRounds(handle::BoosterHandle, out::Ptr{Cint})::Cint
 end
 
 function XGBoosterSetParam(handle, name, value)
-    @ccall libxgboost.XGBoosterSetParam(handle::BoosterHandle, name::Ptr{Cchar}, value::Ptr{Cchar})::Cint
+    @ccall lib_xgboost.XGBoosterSetParam(handle::BoosterHandle, name::Ptr{Cchar}, value::Ptr{Cchar})::Cint
 end
 
 function XGBoosterGetNumFeature(handle, out)
-    @ccall libxgboost.XGBoosterGetNumFeature(handle::BoosterHandle, out::Ptr{bst_ulong})::Cint
+    @ccall lib_xgboost.XGBoosterGetNumFeature(handle::BoosterHandle, out::Ptr{bst_ulong})::Cint
 end
 
 function XGBoosterUpdateOneIter(handle, iter, dtrain)
-    @ccall libxgboost.XGBoosterUpdateOneIter(handle::BoosterHandle, iter::Cint, dtrain::DMatrixHandle)::Cint
+    @ccall lib_xgboost.XGBoosterUpdateOneIter(handle::BoosterHandle, iter::Cint, dtrain::DMatrixHandle)::Cint
 end
 
 function XGBoosterBoostOneIter(handle, dtrain, grad, hess, len)
-    @ccall libxgboost.XGBoosterBoostOneIter(handle::BoosterHandle, dtrain::DMatrixHandle, grad::Ptr{Cfloat}, hess::Ptr{Cfloat}, len::bst_ulong)::Cint
+    @ccall lib_xgboost.XGBoosterBoostOneIter(handle::BoosterHandle, dtrain::DMatrixHandle, grad::Ptr{Cfloat}, hess::Ptr{Cfloat}, len::bst_ulong)::Cint
 end
 
 function XGBoosterEvalOneIter(handle, iter, dmats, evnames, len, out_result)
-    @ccall libxgboost.XGBoosterEvalOneIter(handle::BoosterHandle, iter::Cint, dmats::Ptr{DMatrixHandle}, evnames::Ptr{Ptr{Cchar}}, len::bst_ulong, out_result::Ptr{Ptr{Cchar}})::Cint
+    @ccall lib_xgboost.XGBoosterEvalOneIter(handle::BoosterHandle, iter::Cint, dmats::Ptr{DMatrixHandle}, evnames::Ptr{Ptr{Cchar}}, len::bst_ulong, out_result::Ptr{Ptr{Cchar}})::Cint
 end
 
 function XGBoosterPredict(handle, dmat, option_mask, ntree_limit, training, out_len, out_result)
-    @ccall libxgboost.XGBoosterPredict(handle::BoosterHandle, dmat::DMatrixHandle, option_mask::Cint, ntree_limit::Cuint, training::Cint, out_len::Ptr{bst_ulong}, out_result::Ptr{Ptr{Cfloat}})::Cint
+    @ccall lib_xgboost.XGBoosterPredict(handle::BoosterHandle, dmat::DMatrixHandle, option_mask::Cint, ntree_limit::Cuint, training::Cint, out_len::Ptr{bst_ulong}, out_result::Ptr{Ptr{Cfloat}})::Cint
 end
 
 function XGBoosterPredictFromDMatrix(handle, dmat, config, out_shape, out_dim, out_result)
-    @ccall libxgboost.XGBoosterPredictFromDMatrix(handle::BoosterHandle, dmat::DMatrixHandle, config::Ptr{Cchar}, out_shape::Ptr{Ptr{bst_ulong}}, out_dim::Ptr{bst_ulong}, out_result::Ptr{Ptr{Cfloat}})::Cint
+    @ccall lib_xgboost.XGBoosterPredictFromDMatrix(handle::BoosterHandle, dmat::DMatrixHandle, config::Ptr{Cchar}, out_shape::Ptr{Ptr{bst_ulong}}, out_dim::Ptr{bst_ulong}, out_result::Ptr{Ptr{Cfloat}})::Cint
 end
 
 function XGBoosterPredictFromDense(handle, values, config, m, out_shape, out_dim, out_result)
-    @ccall libxgboost.XGBoosterPredictFromDense(handle::BoosterHandle, values::Ptr{Cchar}, config::Ptr{Cchar}, m::DMatrixHandle, out_shape::Ptr{Ptr{bst_ulong}}, out_dim::Ptr{bst_ulong}, out_result::Ptr{Ptr{Cfloat}})::Cint
+    @ccall lib_xgboost.XGBoosterPredictFromDense(handle::BoosterHandle, values::Ptr{Cchar}, config::Ptr{Cchar}, m::DMatrixHandle, out_shape::Ptr{Ptr{bst_ulong}}, out_dim::Ptr{bst_ulong}, out_result::Ptr{Ptr{Cfloat}})::Cint
 end
 
 function XGBoosterPredictFromCSR(handle, indptr, indices, values, ncol, config, m, out_shape, out_dim, out_result)
-    @ccall libxgboost.XGBoosterPredictFromCSR(handle::BoosterHandle, indptr::Ptr{Cchar}, indices::Ptr{Cchar}, values::Ptr{Cchar}, ncol::bst_ulong, config::Ptr{Cchar}, m::DMatrixHandle, out_shape::Ptr{Ptr{bst_ulong}}, out_dim::Ptr{bst_ulong}, out_result::Ptr{Ptr{Cfloat}})::Cint
+    @ccall lib_xgboost.XGBoosterPredictFromCSR(handle::BoosterHandle, indptr::Ptr{Cchar}, indices::Ptr{Cchar}, values::Ptr{Cchar}, ncol::bst_ulong, config::Ptr{Cchar}, m::DMatrixHandle, out_shape::Ptr{Ptr{bst_ulong}}, out_dim::Ptr{bst_ulong}, out_result::Ptr{Ptr{Cfloat}})::Cint
 end
 
 function XGBoosterPredictFromCudaArray(handle, values, config, m, out_shape, out_dim, out_result)
-    @ccall libxgboost.XGBoosterPredictFromCudaArray(handle::BoosterHandle, values::Ptr{Cchar}, config::Ptr{Cchar}, m::DMatrixHandle, out_shape::Ptr{Ptr{bst_ulong}}, out_dim::Ptr{bst_ulong}, out_result::Ptr{Ptr{Cfloat}})::Cint
+    @ccall lib_xgboost.XGBoosterPredictFromCudaArray(handle::BoosterHandle, values::Ptr{Cchar}, config::Ptr{Cchar}, m::DMatrixHandle, out_shape::Ptr{Ptr{bst_ulong}}, out_dim::Ptr{bst_ulong}, out_result::Ptr{Ptr{Cfloat}})::Cint
 end
 
 function XGBoosterPredictFromCudaColumnar(handle, values, config, m, out_shape, out_dim, out_result)
-    @ccall libxgboost.XGBoosterPredictFromCudaColumnar(handle::BoosterHandle, values::Ptr{Cchar}, config::Ptr{Cchar}, m::DMatrixHandle, out_shape::Ptr{Ptr{bst_ulong}}, out_dim::Ptr{bst_ulong}, out_result::Ptr{Ptr{Cfloat}})::Cint
+    @ccall lib_xgboost.XGBoosterPredictFromCudaColumnar(handle::BoosterHandle, values::Ptr{Cchar}, config::Ptr{Cchar}, m::DMatrixHandle, out_shape::Ptr{Ptr{bst_ulong}}, out_dim::Ptr{bst_ulong}, out_result::Ptr{Ptr{Cfloat}})::Cint
 end
 
 function XGBoosterLoadModel(handle, fname)
-    @ccall libxgboost.XGBoosterLoadModel(handle::BoosterHandle, fname::Ptr{Cchar})::Cint
+    @ccall lib_xgboost.XGBoosterLoadModel(handle::BoosterHandle, fname::Ptr{Cchar})::Cint
 end
 
 function XGBoosterSaveModel(handle, fname)
-    @ccall libxgboost.XGBoosterSaveModel(handle::BoosterHandle, fname::Ptr{Cchar})::Cint
+    @ccall lib_xgboost.XGBoosterSaveModel(handle::BoosterHandle, fname::Ptr{Cchar})::Cint
 end
 
 function XGBoosterLoadModelFromBuffer(handle, buf, len)
-    @ccall libxgboost.XGBoosterLoadModelFromBuffer(handle::BoosterHandle, buf::Ptr{Cvoid}, len::bst_ulong)::Cint
+    @ccall lib_xgboost.XGBoosterLoadModelFromBuffer(handle::BoosterHandle, buf::Ptr{Cvoid}, len::bst_ulong)::Cint
 end
 
 function XGBoosterSaveModelToBuffer(handle, config, out_len, out_dptr)
-    @ccall libxgboost.XGBoosterSaveModelToBuffer(handle::BoosterHandle, config::Ptr{Cchar}, out_len::Ptr{bst_ulong}, out_dptr::Ptr{Ptr{Cchar}})::Cint
+    @ccall lib_xgboost.XGBoosterSaveModelToBuffer(handle::BoosterHandle, config::Ptr{Cchar}, out_len::Ptr{bst_ulong}, out_dptr::Ptr{Ptr{Cchar}})::Cint
 end
 
 function XGBoosterGetModelRaw(handle, out_len, out_dptr)
-    @ccall libxgboost.XGBoosterGetModelRaw(handle::BoosterHandle, out_len::Ptr{bst_ulong}, out_dptr::Ptr{Ptr{Cchar}})::Cint
+    @ccall lib_xgboost.XGBoosterGetModelRaw(handle::BoosterHandle, out_len::Ptr{bst_ulong}, out_dptr::Ptr{Ptr{Cchar}})::Cint
 end
 
 function XGBoosterSerializeToBuffer(handle, out_len, out_dptr)
-    @ccall libxgboost.XGBoosterSerializeToBuffer(handle::BoosterHandle, out_len::Ptr{bst_ulong}, out_dptr::Ptr{Ptr{Cchar}})::Cint
+    @ccall lib_xgboost.XGBoosterSerializeToBuffer(handle::BoosterHandle, out_len::Ptr{bst_ulong}, out_dptr::Ptr{Ptr{Cchar}})::Cint
 end
 
 function XGBoosterUnserializeFromBuffer(handle, buf, len)
-    @ccall libxgboost.XGBoosterUnserializeFromBuffer(handle::BoosterHandle, buf::Ptr{Cvoid}, len::bst_ulong)::Cint
+    @ccall lib_xgboost.XGBoosterUnserializeFromBuffer(handle::BoosterHandle, buf::Ptr{Cvoid}, len::bst_ulong)::Cint
 end
 
 function XGBoosterLoadRabitCheckpoint(handle, version)
-    @ccall libxgboost.XGBoosterLoadRabitCheckpoint(handle::BoosterHandle, version::Ptr{Cint})::Cint
+    @ccall lib_xgboost.XGBoosterLoadRabitCheckpoint(handle::BoosterHandle, version::Ptr{Cint})::Cint
 end
 
 function XGBoosterSaveRabitCheckpoint(handle)
-    @ccall libxgboost.XGBoosterSaveRabitCheckpoint(handle::BoosterHandle)::Cint
+    @ccall lib_xgboost.XGBoosterSaveRabitCheckpoint(handle::BoosterHandle)::Cint
 end
 
 function XGBoosterSaveJsonConfig(handle, out_len, out_str)
-    @ccall libxgboost.XGBoosterSaveJsonConfig(handle::BoosterHandle, out_len::Ptr{bst_ulong}, out_str::Ptr{Ptr{Cchar}})::Cint
+    @ccall lib_xgboost.XGBoosterSaveJsonConfig(handle::BoosterHandle, out_len::Ptr{bst_ulong}, out_str::Ptr{Ptr{Cchar}})::Cint
 end
 
 function XGBoosterLoadJsonConfig(handle, config)
-    @ccall libxgboost.XGBoosterLoadJsonConfig(handle::BoosterHandle, config::Ptr{Cchar})::Cint
+    @ccall lib_xgboost.XGBoosterLoadJsonConfig(handle::BoosterHandle, config::Ptr{Cchar})::Cint
 end
 
 function XGBoosterDumpModel(handle, fmap, with_stats, out_len, out_dump_array)
-    @ccall libxgboost.XGBoosterDumpModel(handle::BoosterHandle, fmap::Ptr{Cchar}, with_stats::Cint, out_len::Ptr{bst_ulong}, out_dump_array::Ptr{Ptr{Ptr{Cchar}}})::Cint
+    @ccall lib_xgboost.XGBoosterDumpModel(handle::BoosterHandle, fmap::Ptr{Cchar}, with_stats::Cint, out_len::Ptr{bst_ulong}, out_dump_array::Ptr{Ptr{Ptr{Cchar}}})::Cint
 end
 
 function XGBoosterDumpModelEx(handle, fmap, with_stats, format, out_len, out_dump_array)
-    @ccall libxgboost.XGBoosterDumpModelEx(handle::BoosterHandle, fmap::Ptr{Cchar}, with_stats::Cint, format::Ptr{Cchar}, out_len::Ptr{bst_ulong}, out_dump_array::Ptr{Ptr{Ptr{Cchar}}})::Cint
+    @ccall lib_xgboost.XGBoosterDumpModelEx(handle::BoosterHandle, fmap::Ptr{Cchar}, with_stats::Cint, format::Ptr{Cchar}, out_len::Ptr{bst_ulong}, out_dump_array::Ptr{Ptr{Ptr{Cchar}}})::Cint
 end
 
 function XGBoosterDumpModelWithFeatures(handle, fnum, fname, ftype, with_stats, out_len, out_models)
-    @ccall libxgboost.XGBoosterDumpModelWithFeatures(handle::BoosterHandle, fnum::Cint, fname::Ptr{Ptr{Cchar}}, ftype::Ptr{Ptr{Cchar}}, with_stats::Cint, out_len::Ptr{bst_ulong}, out_models::Ptr{Ptr{Ptr{Cchar}}})::Cint
+    @ccall lib_xgboost.XGBoosterDumpModelWithFeatures(handle::BoosterHandle, fnum::Cint, fname::Ptr{Ptr{Cchar}}, ftype::Ptr{Ptr{Cchar}}, with_stats::Cint, out_len::Ptr{bst_ulong}, out_models::Ptr{Ptr{Ptr{Cchar}}})::Cint
 end
 
 function XGBoosterDumpModelExWithFeatures(handle, fnum, fname, ftype, with_stats, format, out_len, out_models)
-    @ccall libxgboost.XGBoosterDumpModelExWithFeatures(handle::BoosterHandle, fnum::Cint, fname::Ptr{Ptr{Cchar}}, ftype::Ptr{Ptr{Cchar}}, with_stats::Cint, format::Ptr{Cchar}, out_len::Ptr{bst_ulong}, out_models::Ptr{Ptr{Ptr{Cchar}}})::Cint
+    @ccall lib_xgboost.XGBoosterDumpModelExWithFeatures(handle::BoosterHandle, fnum::Cint, fname::Ptr{Ptr{Cchar}}, ftype::Ptr{Ptr{Cchar}}, with_stats::Cint, format::Ptr{Cchar}, out_len::Ptr{bst_ulong}, out_models::Ptr{Ptr{Ptr{Cchar}}})::Cint
 end
 
 function XGBoosterGetAttr(handle, key, out, success)
-    @ccall libxgboost.XGBoosterGetAttr(handle::BoosterHandle, key::Ptr{Cchar}, out::Ptr{Ptr{Cchar}}, success::Ptr{Cint})::Cint
+    @ccall lib_xgboost.XGBoosterGetAttr(handle::BoosterHandle, key::Ptr{Cchar}, out::Ptr{Ptr{Cchar}}, success::Ptr{Cint})::Cint
 end
 
 function XGBoosterSetAttr(handle, key, value)
-    @ccall libxgboost.XGBoosterSetAttr(handle::BoosterHandle, key::Ptr{Cchar}, value::Ptr{Cchar})::Cint
+    @ccall lib_xgboost.XGBoosterSetAttr(handle::BoosterHandle, key::Ptr{Cchar}, value::Ptr{Cchar})::Cint
 end
 
 function XGBoosterGetAttrNames(handle, out_len, out)
-    @ccall libxgboost.XGBoosterGetAttrNames(handle::BoosterHandle, out_len::Ptr{bst_ulong}, out::Ptr{Ptr{Ptr{Cchar}}})::Cint
+    @ccall lib_xgboost.XGBoosterGetAttrNames(handle::BoosterHandle, out_len::Ptr{bst_ulong}, out::Ptr{Ptr{Ptr{Cchar}}})::Cint
 end
 
 function XGBoosterSetStrFeatureInfo(handle, field, features, size)
-    @ccall libxgboost.XGBoosterSetStrFeatureInfo(handle::BoosterHandle, field::Ptr{Cchar}, features::Ptr{Ptr{Cchar}}, size::bst_ulong)::Cint
+    @ccall lib_xgboost.XGBoosterSetStrFeatureInfo(handle::BoosterHandle, field::Ptr{Cchar}, features::Ptr{Ptr{Cchar}}, size::bst_ulong)::Cint
 end
 
 function XGBoosterGetStrFeatureInfo(handle, field, len, out_features)
-    @ccall libxgboost.XGBoosterGetStrFeatureInfo(handle::BoosterHandle, field::Ptr{Cchar}, len::Ptr{bst_ulong}, out_features::Ptr{Ptr{Ptr{Cchar}}})::Cint
+    @ccall lib_xgboost.XGBoosterGetStrFeatureInfo(handle::BoosterHandle, field::Ptr{Cchar}, len::Ptr{bst_ulong}, out_features::Ptr{Ptr{Ptr{Cchar}}})::Cint
 end
 
 function XGBoosterFeatureScore(handle, config, out_n_features, out_features, out_dim, out_shape, out_scores)
-    @ccall libxgboost.XGBoosterFeatureScore(handle::BoosterHandle, config::Ptr{Cchar}, out_n_features::Ptr{bst_ulong}, out_features::Ptr{Ptr{Ptr{Cchar}}}, out_dim::Ptr{bst_ulong}, out_shape::Ptr{Ptr{bst_ulong}}, out_scores::Ptr{Ptr{Cfloat}})::Cint
+    @ccall lib_xgboost.XGBoosterFeatureScore(handle::BoosterHandle, config::Ptr{Cchar}, out_n_features::Ptr{bst_ulong}, out_features::Ptr{Ptr{Ptr{Cchar}}}, out_dim::Ptr{bst_ulong}, out_shape::Ptr{Ptr{bst_ulong}}, out_scores::Ptr{Ptr{Cfloat}})::Cint
 end
 
 function XGCommunicatorInit(config)
-    @ccall libxgboost.XGCommunicatorInit(config::Ptr{Cchar})::Cint
+    @ccall lib_xgboost.XGCommunicatorInit(config::Ptr{Cchar})::Cint
 end
 
 function XGCommunicatorFinalize()
-    @ccall libxgboost.XGCommunicatorFinalize()::Cint
+    @ccall lib_xgboost.XGCommunicatorFinalize()::Cint
 end
 
 function XGCommunicatorGetRank()
-    @ccall libxgboost.XGCommunicatorGetRank()::Cint
+    @ccall lib_xgboost.XGCommunicatorGetRank()::Cint
 end
 
 function XGCommunicatorGetWorldSize()
-    @ccall libxgboost.XGCommunicatorGetWorldSize()::Cint
+    @ccall lib_xgboost.XGCommunicatorGetWorldSize()::Cint
 end
 
 function XGCommunicatorIsDistributed()
-    @ccall libxgboost.XGCommunicatorIsDistributed()::Cint
+    @ccall lib_xgboost.XGCommunicatorIsDistributed()::Cint
 end
 
 function XGCommunicatorPrint(message)
-    @ccall libxgboost.XGCommunicatorPrint(message::Ptr{Cchar})::Cint
+    @ccall lib_xgboost.XGCommunicatorPrint(message::Ptr{Cchar})::Cint
 end
 
 function XGCommunicatorGetProcessorName(name_str)
-    @ccall libxgboost.XGCommunicatorGetProcessorName(name_str::Ptr{Ptr{Cchar}})::Cint
+    @ccall lib_xgboost.XGCommunicatorGetProcessorName(name_str::Ptr{Ptr{Cchar}})::Cint
 end
 
 function XGCommunicatorBroadcast(send_receive_buffer, size, root)
-    @ccall libxgboost.XGCommunicatorBroadcast(send_receive_buffer::Ptr{Cvoid}, size::Csize_t, root::Cint)::Cint
+    @ccall lib_xgboost.XGCommunicatorBroadcast(send_receive_buffer::Ptr{Cvoid}, size::Csize_t, root::Cint)::Cint
 end
 
 function XGCommunicatorAllreduce(send_receive_buffer, count, data_type, op)
-    @ccall libxgboost.XGCommunicatorAllreduce(send_receive_buffer::Ptr{Cvoid}, count::Csize_t, data_type::Cint, op::Cint)::Cint
+    @ccall lib_xgboost.XGCommunicatorAllreduce(send_receive_buffer::Ptr{Cvoid}, count::Csize_t, data_type::Cint, op::Cint)::Cint
 end
 
 # Skipping MacroDefinition: XGB_DLL XGB_EXTERN_C __attribute__ ( ( visibility ( "default" ) ) )

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -355,7 +355,7 @@ end
 end
 
 # only test GPU cababilities if an appropriate artifact is available
-XGBoost_GPU_jll.is_available() && @testset "cuda" begin
+has_cuda() && @testset "cuda" begin
     @info("runing CUDA tests")
 
     X = randn(Float32, 4, 5)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,4 +1,5 @@
 using XGBoost
+using XGBoost_GPU_jll
 using CUDA: has_cuda, cu
 import Term
 using Random, SparseArrays
@@ -353,7 +354,8 @@ end
     @test predict(b, randn(MersenneTwister(998), 10,2)) ≠ ŷ
 end
 
-has_cuda() && @testset "cuda" begin
+# only test GPU cababilities if an appropriate device + artifact is available
+has_cuda() && XGBoost_GPU_jll.is_available() && @testset "cuda" begin
     @info("runing CUDA tests")
 
     X = randn(Float32, 4, 5)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -354,8 +354,8 @@ end
     @test predict(b, randn(MersenneTwister(998), 10,2)) ≠ ŷ
 end
 
-# only test GPU cababilities if an appropriate device + artifact is available
-has_cuda() && XGBoost_GPU_jll.is_available() && @testset "cuda" begin
+# only test GPU cababilities if an appropriate artifact is available
+XGBoost_GPU_jll.is_available() && @testset "cuda" begin
     @info("runing CUDA tests")
 
     X = randn(Float32, 4, 5)


### PR DESCRIPTION
This is to fix the issue mentioned [here](https://github.com/JuliaPackaging/Yggdrasil/issues/11918) where XGBoost wasn't working when users had CUDA v13 present. Now the behaviour of the package is to attempt to load GPU-compatible artifacts for XGBoost via XGBoost_GPU_jll, but if it can't find a compatible artifact it falls back to the standard CPU build in XGBoost_jll