### PR TITLE
Replaced Ptr{Int8} with Ptr{Cchar} for ARM compatibility

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,6 +23,9 @@ jobs:
           - os: windows-latest
             version: '1'
             arch: x64
+          - os: ubuntu-24.04-arm
+            version: '1'
+            arch: aarch64
     steps:
       - uses: actions/checkout@v2
       - uses: julia-actions/setup-julia@v1

--- a/src/booster.jl
+++ b/src/booster.jl
@@ -198,7 +198,7 @@ end
 function save(b::Booster, ::Type{Vector{UInt8}}; format::AbstractString="json")
     cfg = JSON.json(Dict("format"=>format))
     olen = Ref{Lib.bst_ulong}()
-    o = Ref{Ptr{Int8}}()
+    o = Ref{Ptr{Cchar}}()
     xgbcall(XGBoosterSaveModelToBuffer, b.handle, cfg, olen, o)
     unsafe_wrap(Array, convert(Ptr{UInt8}, o[]), olen[])
 end
@@ -245,7 +245,7 @@ The output of this function can be loaded with [`deserialize`](@ref).
 """
 function serialize(b::Booster)
     olen = Ref{Lib.bst_ulong}()
-    o = Ref{Ptr{Int8}}()  # don't know why it insists on Int8
+    o = Ref{Ptr{Cchar}}()  # don't know why it insists on Cchar
     xgbcall(XGBoosterSerializeToBuffer, b.handle, olen, o)
     unsafe_wrap(Array, convert(Ptr{UInt8}, o[]), olen[])
 end
@@ -336,7 +336,7 @@ predict(b::Booster, Xy::DMatrix; kw...) = copy(predict_nocopy(b, Xy; kw...))
 predict(b::Booster, Xy; kw...) = predict(b, DMatrix(Xy); kw...)
 
 function evaliter(b::Booster, watch, n::Integer=1)
-    o = Ref{Ptr{Int8}}()
+    o = Ref{Ptr{Cchar}}()
     names = collect(Iterators.map(string, keys(watch)))
     watch = collect(Iterators.map(x -> x.handle, values(watch)))
     xgbcall(XGBoosterEvalOneIter, b.handle, n, watch, names, length(watch), o)


### PR DESCRIPTION
## Summary

Adds ARM64 CI coverage and fixes an ARM compatibility issue in `booster.jl`. This PR fixes #218 

## Changes

### CI (`.github/workflows/ci.yml`)
- Added `ubuntu-24.04-arm` to the test matrix so the package is validated on AArch64 in addition to x86-64

### Bug Fix (`src/booster.jl`)
- Changed `Ref{Ptr{Int8}}()` to `Ref{Ptr{Cchar}}()` to use the portable C type alias instead of a platform-specific integer type

## Motivation

`Int8` and `Cchar` are not equivalent on all architectures — on ARM, `char` is unsigned by default, making `Ptr{Int8}` incorrect. Using `Cchar` correctly maps to the platform's native `char` type and matches the types expected by the underlying libxgboost C API.

The new `ubuntu-24.04-arm` CI job (a free GitHub-hosted runner for public repositories) will catch regressions like this going forward.

## Notes

- `ubuntu-latest-arm` is **not** a valid GitHub runner label; `ubuntu-24.04-arm` (Ubuntu Noble) is the correct label per the [GitHub-hosted runners reference](https://docs.github.com/en/actions/reference/runners/github-hosted-runners).
- The ARM CI job runs Julia `1` (latest stable); additional Julia versions can be added later if needed.